### PR TITLE
Display category experts posts specially

### DIFF
--- a/app/controllers/category_experts_controller.rb
+++ b/app/controllers/category_experts_controller.rb
@@ -25,9 +25,9 @@ class CategoryExpertsController < ApplicationController
 
   def approve_post
     post_handler = CategoryExperts::PostHandler.new(post: @post)
-    post_handler.mark_post_as_approved
+    group_name = post_handler.mark_post_as_approved
 
-    render json: success_json
+    render json: { group_name: group_name }
   end
 
   def unapprove_post
@@ -41,7 +41,7 @@ class CategoryExpertsController < ApplicationController
 
   def ensure_staff_and_enabled
     unless current_user && current_user.staff? && SiteSetting.category_experts_posts_require_approval
-      raise Discoures::NotFound
+      raise Discourse::NotFound
     end
   end
 

--- a/app/controllers/category_experts_controller.rb
+++ b/app/controllers/category_experts_controller.rb
@@ -41,7 +41,7 @@ class CategoryExpertsController < ApplicationController
 
   def ensure_staff_and_enabled
     unless current_user && current_user.staff? && SiteSetting.category_experts_posts_require_approval
-      raise Discourse::NotFound
+      raise Discourse::InvalidAccess
     end
   end
 

--- a/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
+++ b/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
@@ -1,0 +1,79 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+function initializeWithApi(api) {
+  const requiresApproval = api.container.lookup("site-settings:main")
+    .category_experts_posts_require_approval;
+
+  if (requiresApproval) {
+    api.includePostAttributes(
+      "needs_category_expert_approval",
+      "category_expert_approved",
+      "can_manage_category_expert_posts"
+    );
+
+    api.addPostMenuButton("category expert approved", (attrs, state) => {
+      if (!attrs.can_manage_category_expert_posts) return;
+
+      if (attrs.needs_category_expert_approval) {
+        return {
+          action: "approveCategoryExpertPost",
+          icon: "thumbs-up",
+          className: "approve",
+          title: "category_experts.approve",
+          label: "category_experts.approve",
+          position: "first",
+        };
+      } else if (attrs.category_expert_approved) {
+        return {
+          action: "unapproveCategoryExpertPost",
+          icon: "thumbs-down",
+          className: "unapprove",
+          title: "category_experts.unapprove",
+          position: "second-last-hidden",
+        };
+      }
+    });
+
+    function setPostCategoryExpertAttributes(post, opts = { approved: true }) {
+      post.setProperties({
+        needs_category_expert_approval: !opts.approved,
+        category_expert_approved: opts.approved,
+      });
+
+      ajax(`/category-experts/${opts.approved ? "approve" : "unapprove"}`, {
+        type: "POST",
+        data: { post_id: post.id },
+      }).catch(popupAjaxError);
+    }
+
+    api.attachWidgetAction("post", "approveCategoryExpertPost", function () {
+      setPostCategoryExpertAttributes(this.model, { approved: true });
+    });
+
+    api.attachWidgetAction("post", "unapproveCategoryExpertPost", function () {
+      setPostCategoryExpertAttributes(this.model, { approved: false });
+    });
+  }
+
+  api.decorateCookedElement(
+    (element, decoratorHelper) => {
+      const model = decoratorHelper ? decoratorHelper.getModel() : null;
+      if (model) {
+        console.log(model);
+      }
+    },
+    { id: "discourse-experts" }
+  );
+}
+
+export default {
+  name: "discourse-experts-post-decorator",
+
+  initialize() {
+    withPluginApi("0.10.1", (api) => {
+      initializeWithApi(api);
+    });
+  },
+};

--- a/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
+++ b/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
@@ -1,35 +1,45 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { next } from "@ember/runloop";
 
 function initializeWithApi(api) {
   const requiresApproval = api.container.lookup("site-settings:main")
     .category_experts_posts_require_approval;
 
   if (requiresApproval) {
+    console.log("here too")
+    const appEvents = api.container.lookup("service:app-events");
+
     api.includePostAttributes(
       "needs_category_expert_approval",
       "category_expert_approved",
       "can_manage_category_expert_posts"
     );
 
-    api.addPostMenuButton("category expert approved", (attrs, state) => {
+    api.addPostMenuButton("category-expert-post-approval", (attrs, state) => {
       if (!attrs.can_manage_category_expert_posts) return;
 
-      if (attrs.needs_category_expert_approval) {
+      if (
+        attrs.needs_category_expert_approval &&
+        !attrs.category_expert_approved
+      ) {
         return {
           action: "approveCategoryExpertPost",
           icon: "thumbs-up",
-          className: "approve",
+          className: "approve-category-expert-post",
           title: "category_experts.approve",
           label: "category_experts.approve",
           position: "first",
         };
-      } else if (attrs.category_expert_approved) {
+      } else if (
+        attrs.category_expert_approved &&
+        !attrs.needs_category_expert_approval
+      ) {
         return {
           action: "unapproveCategoryExpertPost",
           icon: "thumbs-down",
-          className: "unapprove",
+          className: "unapprove-category-expert-post",
           title: "category_experts.unapprove",
           position: "second-last-hidden",
         };
@@ -37,15 +47,19 @@ function initializeWithApi(api) {
     });
 
     function setPostCategoryExpertAttributes(post, opts = { approved: true }) {
-      post.setProperties({
-        needs_category_expert_approval: !opts.approved,
-        category_expert_approved: opts.approved,
-      });
-
       ajax(`/category-experts/${opts.approved ? "approve" : "unapprove"}`, {
         type: "POST",
         data: { post_id: post.id },
-      }).catch(popupAjaxError);
+      })
+        .then((response) => {
+          post.setProperties({
+            needs_category_expert_approval: !opts.approved,
+            category_expert_approved: opts.approved ? response.group_name : false,
+          });
+
+          appEvents.trigger("post-stream:refresh", { id: post.id });
+        })
+        .catch(popupAjaxError);
     }
 
     api.attachWidgetAction("post", "approveCategoryExpertPost", function () {
@@ -57,15 +71,24 @@ function initializeWithApi(api) {
     });
   }
 
-  api.decorateCookedElement(
-    (element, decoratorHelper) => {
-      const model = decoratorHelper ? decoratorHelper.getModel() : null;
-      if (model) {
-        console.log(model);
+  api.decorateWidget("post:after", (helper) => {
+    const post = helper.getModel();
+    next(() => {
+      const article = document.querySelector(
+        `article[data-post-id="${post.id}"]`
+      );
+      if (!article) return;
+
+      if (post.category_expert_approved) {
+        article.classList.add("category-expert-post");
+        article.classList.add(
+          `category-expert-${post.category_expert_approved}`
+        );
+      } else if (post.needs_category_expert_approval) {
+        article.classList.remove("category-expert-post");
       }
-    },
-    { id: "discourse-experts" }
-  );
+    });
+  });
 }
 
 export default {

--- a/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
+++ b/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
@@ -12,7 +12,7 @@ function initializeWithApi(api) {
 
     api.includePostAttributes(
       "needs_category_expert_approval",
-      "category_expert_approved",
+      "category_expert_approved_group",
       "can_manage_category_expert_posts"
     );
 
@@ -21,7 +21,7 @@ function initializeWithApi(api) {
 
       if (
         attrs.needs_category_expert_approval &&
-        !attrs.category_expert_approved
+        !attrs.category_expert_approved_group
       ) {
         return {
           action: "approveCategoryExpertPost",
@@ -32,7 +32,7 @@ function initializeWithApi(api) {
           position: "first",
         };
       } else if (
-        attrs.category_expert_approved &&
+        attrs.category_expert_approved_group &&
         !attrs.needs_category_expert_approval
       ) {
         return {
@@ -53,7 +53,7 @@ function initializeWithApi(api) {
         .then((response) => {
           post.setProperties({
             needs_category_expert_approval: !opts.approved,
-            category_expert_approved: opts.approved ? response.group_name : false,
+            category_expert_approved_group: opts.approved ? response.group_name : false,
           });
 
           appEvents.trigger("post-stream:refresh", { id: post.id });
@@ -78,10 +78,10 @@ function initializeWithApi(api) {
       );
       if (!article) return;
 
-      if (post.category_expert_approved) {
+      if (post.category_expert_approved_group) {
         article.classList.add("category-expert-post");
         article.classList.add(
-          `category-expert-${post.category_expert_approved}`
+          `category-expert-${post.category_expert_approved_group}`
         );
       } else if (post.needs_category_expert_approval) {
         article.classList.remove("category-expert-post");

--- a/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
+++ b/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
@@ -8,7 +8,6 @@ function initializeWithApi(api) {
     .category_experts_posts_require_approval;
 
   if (requiresApproval) {
-    console.log("here too")
     const appEvents = api.container.lookup("service:app-events");
 
     api.includePostAttributes(

--- a/assets/javascripts/discourse/pre-initializers/extend-for-category-experts.js
+++ b/assets/javascripts/discourse/pre-initializers/extend-for-category-experts.js
@@ -1,5 +1,5 @@
 import Category from "discourse/models/category";
-import { and, equal } from "@ember/object/computed";
+import { and } from "@ember/object/computed";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 export default {

--- a/assets/javascripts/discourse/pre-initializers/extend-for-category-experts.js
+++ b/assets/javascripts/discourse/pre-initializers/extend-for-category-experts.js
@@ -1,5 +1,5 @@
 import Category from "discourse/models/category";
-import { and } from "@ember/object/computed";
+import { and, equal } from "@ember/object/computed";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 export default {

--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -32,3 +32,9 @@
   font-size: 5em;
   line-height: 1em;
 }
+
+article.category-expert-post {
+  .topic-body, .topic-avatar {
+    border-top: 4px solid $tertiary;
+  }
+}

--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -36,13 +36,13 @@
 
 .time-gap+.topic-post article.category-expert-post {
   .topic-body, .topic-avatar {
-    border-top: 4px solid $tertiary;
+    border-top: 4px solid $success;
   }
 }
 
 article.category-expert-post {
   .topic-body, .topic-avatar {
-    border-top: 4px solid $tertiary;
+    border-top: 4px solid $success;
   }
 }
 

--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -33,8 +33,19 @@
   line-height: 1em;
 }
 
+
+.time-gap+.topic-post article.category-expert-post {
+  .topic-body, .topic-avatar {
+    border-top: 4px solid $tertiary;
+  }
+}
+
 article.category-expert-post {
   .topic-body, .topic-avatar {
     border-top: 4px solid $tertiary;
   }
+}
+
+.post-controls .approve-category-expert-post .d-button-label {
+  margin-left: 7px;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8,7 +8,7 @@ en:
       endorse: "Endorse"
       existing_endorsements: "Endorsed in %{count} categories."
       edit: "Edit"
-      approve: "Approve Category Expert Post"
+      approve: "Approve"
       unapprove: "Unapprove Category Expert Post"
       manage_endorsements:
         title: "Endorse user"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8,6 +8,8 @@ en:
       endorse: "Endorse"
       existing_endorsements: "Endorsed in %{count} categories."
       edit: "Edit"
+      approve: "Approve Category Expert Post"
+      unapprove: "Unapprove Category Expert Post"
       manage_endorsements:
         title: "Endorse user"
         subtitle: "What are %{username}'s strengths?"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,4 @@ en:
   site_settings:
     enable_category_experts: "Enable category experts plugin"
     category_expert_suggestion_threshold: "Suggest category experts after this many endorsements."
+    category_experts_posts_require_approval: "Posts from category experts require staff approval for expert decoration."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,6 @@ plugins:
   category_expert_suggestion_threshold:
     default: 3
     min: 1
+  category_experts_posts_require_approval:
+    default: false
+    client: true

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module CategoryExperts
+  class PostHandler
+    attr_accessor :post, :user
+
+    def initialize(post:, user: nil)
+      @post = post
+      @user = user || post.user
+    end
+
+    def process_new_post
+      ensure_correct_settings
+      SiteSetting.category_experts_posts_require_approval ?
+        mark_post_for_approval :
+        mark_post_as_approved
+    end
+
+    def mark_post_for_approval
+      ensure_correct_settings
+      post.custom_fields[CategoryExperts::IS_APPROVED_EXPERT_POST] = nil
+      post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = true
+      post.save
+
+      topic = post.topic
+      unless topic.custom_fields[CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST]
+        # Topic doesn't have any approved expert posts. Mark as needing approval
+        topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL] = true
+        topic.save
+      end
+    end
+
+    def mark_post_as_approved
+      ensure_correct_settings
+      post.custom_fields[CategoryExperts::IS_APPROVED_EXPERT_POST] = users_expert_group.name
+      post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = nil
+      post.save
+
+      topic = post.topic
+      topic.custom_fields[CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST] = true
+      topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL] = nil
+      topic.save
+    end
+
+    private
+
+    def ensure_correct_settings
+      raise Discourse::InvalidParameters if expert_group_ids.blank? || users_expert_group.nil?
+    end
+
+    def expert_group_ids
+      unsplit_group_ids = post.topic.category.custom_fields[CategoryExperts::CATEGORY_EXPERT_GROUP_IDS]
+      return [] if unsplit_group_ids.nil?
+
+      unsplit_group_ids.split("|").map(&:to_i)
+    end
+
+    def users_expert_group
+      return @users_expert_group if defined?(@users_expert_group) # memoizing a potentially falsy value
+
+      group_id = ((expert_group_ids & user.group_ids) || []).first
+      return nil if group_id.nil?
+
+      @users_expert_group = Group.find_by(id: group_id)
+    end
+  end
+end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -22,13 +22,13 @@ module CategoryExperts
 
       post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = nil
       post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = true
-      post.save
+      post.save!
 
       topic = post.topic
       unless topic.custom_fields[CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST]
         # Topic doesn't have any approved expert posts. Mark as needing approval
         topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL] = true
-        topic.save
+        topic.save!
       end
     end
 
@@ -37,12 +37,12 @@ module CategoryExperts
 
       post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = users_expert_group.name
       post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = nil
-      post.save
+      post.save!
 
       topic = post.topic
       topic.custom_fields[CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST] = true
       topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL] = nil
-      topic.save
+      topic.save!
 
       users_expert_group.name
     end
@@ -64,9 +64,7 @@ module CategoryExperts
       return @users_expert_group if defined?(@users_expert_group) # memoizing a potentially falsy value
 
       group_id = ((expert_group_ids & user.group_ids) || []).first
-      return nil if group_id.nil?
-
-      @users_expert_group = Group.find_by(id: group_id)
+      @users_expert_group = group_id.nil? ? nil : Group.find_by(id: group_id)
     end
   end
 end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -10,7 +10,7 @@ module CategoryExperts
     end
 
     def process_new_post
-      return ensure_correct_settings unless ensure_correct_settings
+      return unless ensure_correct_settings
 
       SiteSetting.category_experts_posts_require_approval ?
         mark_post_for_approval :

--- a/plugin.rb
+++ b/plugin.rb
@@ -9,6 +9,8 @@
 
 register_asset "stylesheets/common.scss"
 
+enabled_site_setting :enable_category_experts
+
 after_initialize do
   [
     "../app/controllers/category_experts_controller",

--- a/plugin.rb
+++ b/plugin.rb
@@ -15,12 +15,17 @@ after_initialize do
     "../app/models/category_expert_endorsement",
     "../app/models/reviewable_category_expert_suggestion",
     "../app/serializers/reviewable_category_expert_suggestion_serializer",
+    "../lib/category_experts/post_handler",
   ].each { |path| require File.expand_path(path, __FILE__) }
 
   module ::CategoryExperts
     PLUGIN_NAME ||= "discourse-category-experts".freeze
     CATEGORY_EXPERT_GROUP_IDS = "category_expert_group_ids"
     CATEGORY_ACCEPTING_ENDORSEMENTS = "category_accepting_endorsements"
+    IS_APPROVED_EXPERT_POST = "category_expert_post"
+    POST_PENDING_EXPERT_APPROVAL = "category_expert_post_pending"
+    TOPIC_HAS_APPROVED_EXPERT_POST = "category_expert_topic_approved_post"
+    TOPIC_NEEDS_EXPERT_POST_APPROVAL = "category_expert_topic_post_needs_approval"
 
     class Engine < ::Rails::Engine
       engine_name CategoryExperts::PLUGIN_NAME
@@ -29,7 +34,14 @@ after_initialize do
   end
 
   register_reviewable_type ReviewableCategoryExpertSuggestion
+
   add_permitted_reviewable_param(:reviewable_category_expert_suggestion, :group_id)
+
+  register_post_custom_field_type(CategoryExperts::IS_APPROVED_EXPERT_POST, :string)
+  register_post_custom_field_type(CategoryExperts::POST_PENDING_EXPERT_APPROVAL, :boolean)
+
+  register_topic_custom_field_type(CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST, :boolean)
+  register_topic_custom_field_type(CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL, :boolean)
 
   if Site.respond_to? :preloaded_category_custom_fields
     Site.preloaded_category_custom_fields << CategoryExperts::CATEGORY_EXPERT_GROUP_IDS
@@ -59,7 +71,32 @@ after_initialize do
     scope.current_user.given_category_expert_endorsements_for(object)
   end
 
+  add_to_serializer(:post, :category_expert_approved) do
+    object.custom_fields[CategoryExperts::IS_APPROVED_EXPERT_POST]
+  end
+
+  add_to_serializer(:post, :needs_category_expert_approval) do
+    object.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL]
+  end
+
+  add_to_serializer(:post, :can_manage_category_expert_posts) do
+    scope.is_staff?
+  end
+
+  NewPostManager.add_handler do |manager|
+    result = manager.perform_create_post
+
+    if result.success?
+      handler = CategoryExperts::PostHandler.new(post: result.post, user: manager.user)
+      handler.process_new_post
+    end
+
+    result
+  end
+
   Discourse::Application.routes.append do
     put "category-experts/endorse/:username" => "category_experts#endorse", constraints: { username: ::RouteFormat.username }
+    post "category-experts/approve" => "category_experts#approve_post"
+    post "category-experts/unapprove" => "category_experts#unapprove_post"
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -22,7 +22,7 @@ after_initialize do
     PLUGIN_NAME ||= "discourse-category-experts".freeze
     CATEGORY_EXPERT_GROUP_IDS = "category_expert_group_ids"
     CATEGORY_ACCEPTING_ENDORSEMENTS = "category_accepting_endorsements"
-    IS_APPROVED_EXPERT_POST = "category_expert_post"
+    POST_APPROVED_GROUP_NAME = "category_expert_post"
     POST_PENDING_EXPERT_APPROVAL = "category_expert_post_pending"
     TOPIC_HAS_APPROVED_EXPERT_POST = "category_expert_topic_approved_post"
     TOPIC_NEEDS_EXPERT_POST_APPROVAL = "category_expert_topic_post_needs_approval"
@@ -37,7 +37,7 @@ after_initialize do
 
   add_permitted_reviewable_param(:reviewable_category_expert_suggestion, :group_id)
 
-  register_post_custom_field_type(CategoryExperts::IS_APPROVED_EXPERT_POST, :string)
+  register_post_custom_field_type(CategoryExperts::POST_APPROVED_GROUP_NAME, :string)
   register_post_custom_field_type(CategoryExperts::POST_PENDING_EXPERT_APPROVAL, :boolean)
 
   register_topic_custom_field_type(CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST, :boolean)
@@ -71,8 +71,8 @@ after_initialize do
     scope.current_user.given_category_expert_endorsements_for(object)
   end
 
-  add_to_serializer(:post, :category_expert_approved) do
-    object.custom_fields[CategoryExperts::IS_APPROVED_EXPERT_POST]
+  add_to_serializer(:post, :category_expert_approved_group) do
+    object.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]
   end
 
   add_to_serializer(:post, :needs_category_expert_approval) do

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CategoryExperts::PostHandler do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:expert) { Fabricate(:user) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:group) { Fabricate(:group, users: [expert]) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+
+  before do
+    SiteSetting.enable_category_experts
+    SiteSetting.category_expert_suggestion_threshold
+    category.custom_fields[CategoryExperts::CATEGORY_EXPERT_GROUP_IDS] = "#{group.id}|#{group.id + 1}"
+    category.save
+  end
+
+  describe "SiteSetting.category_experts_posts_require_approval enabled" do
+    before do
+      SiteSetting.category_experts_posts_require_approval = true
+    end
+
+    describe "No existing approved expert posts" do
+      it "marks the post as needing approval, as well as the topic" do
+        result = NewPostManager.new(expert, raw: 'this is a new post', topic_id: topic.id).perform
+
+        expect(result.post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL]).to eq(true)
+        expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL]).to eq(true)
+      end
+    end
+
+    describe "With an existing approved expert post" do
+      it "marks the post as needing approval, but not the topic" do
+        post = create_post(topic_id: topic.id, user: expert)
+        CategoryExperts::PostHandler.new(post: post, user: expert).mark_post_as_approved
+
+        result = NewPostManager.new(expert, raw: 'this is a new post', topic_id: topic.id).perform
+
+        expect(result.post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL]).to eq(true)
+        expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL]).to eq(false)
+      end
+    end
+  end
+
+  describe "SiteSetting.category_experts_posts_require_approval disabled" do
+    before do
+      SiteSetting.category_experts_posts_require_approval = false
+    end
+
+    it "marks posts as approved automatically" do
+      result = NewPostManager.new(expert, raw: 'this is a new post', topic_id: topic.id).perform
+
+      expect(result.post.custom_fields[CategoryExperts::IS_APPROVED_EXPERT_POST]).to eq(group.name)
+      expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST]).to eq(true)
+
+      expect(result.post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL]).to eq(false)
+      expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL]).to eq(false)
+    end
+  end
+end

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -14,6 +14,7 @@ describe CategoryExperts::PostHandler do
     SiteSetting.category_expert_suggestion_threshold
     category.custom_fields[CategoryExperts::CATEGORY_EXPERT_GROUP_IDS] = "#{group.id}|#{group.id + 1}"
     category.save
+
   end
 
   describe "SiteSetting.category_experts_posts_require_approval enabled" do
@@ -51,7 +52,7 @@ describe CategoryExperts::PostHandler do
     it "marks posts as approved automatically" do
       result = NewPostManager.new(expert, raw: 'this is a new post', topic_id: topic.id).perform
 
-      expect(result.post.custom_fields[CategoryExperts::IS_APPROVED_EXPERT_POST]).to eq(group.name)
+      expect(result.post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(group.name)
       expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_HAS_APPROVED_EXPERT_POST]).to eq(true)
 
       expect(result.post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL]).to eq(false)

--- a/test/javascripts/acceptance/category-experts-post-test.js
+++ b/test/javascripts/acceptance/category-experts-post-test.js
@@ -1,6 +1,7 @@
 import {
   acceptance,
   exists,
+  query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import topicFixtures from "discourse/tests/fixtures/topic";

--- a/test/javascripts/acceptance/category-experts-post-test.js
+++ b/test/javascripts/acceptance/category-experts-post-test.js
@@ -76,7 +76,7 @@ acceptance(
 
       await click(lastArticle.querySelector("button.show-more-actions"));
 
-      const unapproveBtn = find(
+      const unapproveBtn = query(
         ".widget-button.unapprove-category-expert-post"
       );
       await click(unapproveBtn);

--- a/test/javascripts/acceptance/category-experts-post-test.js
+++ b/test/javascripts/acceptance/category-experts-post-test.js
@@ -1,0 +1,101 @@
+import {
+  acceptance,
+  exists,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
+import topicFixtures from "discourse/tests/fixtures/topic";
+
+const groupName = "some-group";
+
+acceptance(
+  "Discourse Category Experts - Posts - Auto-approved",
+  function (needs) {
+    needs.user();
+    needs.settings({
+      enable_category_experts: true,
+      category_experts_posts_require_approval: false,
+    });
+
+    needs.pretender((server, helper) => {
+      let topicResponse = Object.assign({}, topicFixtures["/t/2480/1.json"]);
+      topicResponse.post_stream.posts[2].category_expert_approved = groupName;
+      server.get("/t/2480.json", () => helper.response(topicResponse));
+    });
+
+    test("Posts with category_expert_approved have the correct classes", async function (assert) {
+      await visit("/t/topic-for-group-moderators/2480");
+
+      const articles = queryAll(".topic-post article");
+      const lastArticle = articles[articles.length - 1];
+
+      assert.ok(lastArticle.classList.contains("category-expert-post"));
+      assert.ok(lastArticle.classList.contains(`category-expert-${groupName}`));
+
+      await click(lastArticle.querySelector("button.show-more-actions"));
+
+      assert.notOk(exists(".widget-button.unapprove-category-expert-post"));
+    });
+  }
+);
+
+acceptance(
+  "Discourse Category Experts - Posts - Need approved",
+  function (needs) {
+    needs.user();
+    needs.settings({
+      enable_category_experts: true,
+      category_experts_posts_require_approval: true,
+    });
+
+    needs.pretender((server, helper) => {
+      let topicResponse = Object.assign({}, topicFixtures["/t/2480/1.json"]);
+      topicResponse.post_stream.posts[1].needs_category_expert_approval = true;
+      topicResponse.post_stream.posts[1].can_manage_category_expert_posts = true;
+
+      topicResponse.post_stream.posts[2].category_expert_approved = groupName;
+      topicResponse.post_stream.posts[2].can_manage_category_expert_posts = true;
+
+      server.get("/t/2480.json", () => helper.response(topicResponse));
+      server.post("/category-experts/unapprove", () => helper.response({}));
+      server.post("/category-experts/approve", () =>
+        helper.response({
+          group_name: groupName,
+        })
+      );
+    });
+
+    test("The unapprove button is present and works for approved posts", async function (assert) {
+      await visit("/t/topic-for-group-moderators/2480");
+
+      const articles = queryAll(".topic-post article");
+      const lastArticle = articles[articles.length - 1];
+
+      assert.ok(lastArticle.classList.contains("category-expert-post"));
+      assert.ok(lastArticle.classList.contains(`category-expert-${groupName}`));
+
+      await click(lastArticle.querySelector("button.show-more-actions"));
+
+      const unapproveBtn = find(
+        ".widget-button.unapprove-category-expert-post"
+      );
+      await click(unapproveBtn);
+
+      assert.notOk(lastArticle.classList.contains("category-expert-post"));
+    });
+
+    test("The approve button is present and works for unapproved posts by category experts", async function (assert) {
+      await visit("/t/topic-for-group-moderators/2480");
+
+      const articles = queryAll(".topic-post article");
+      const article = articles[articles.length - 2];
+
+      assert.notOk(article.classList.contains("category-expert-post"));
+      assert.notOk(article.classList.contains(`category-expert-${groupName}`));
+
+      await click(article.querySelector("button.approve-category-expert-post"));
+
+      assert.ok(article.classList.contains("category-expert-post"));
+      assert.ok(article.classList.contains(`category-expert-${groupName}`));
+    });
+  }
+);

--- a/test/javascripts/acceptance/category-experts-post-test.js
+++ b/test/javascripts/acceptance/category-experts-post-test.js
@@ -18,7 +18,7 @@ acceptance(
 
     needs.pretender((server, helper) => {
       let topicResponse = Object.assign({}, topicFixtures["/t/2480/1.json"]);
-      topicResponse.post_stream.posts[2].category_expert_approved = groupName;
+      topicResponse.post_stream.posts[2].category_expert_approved_group = groupName;
       server.get("/t/2480.json", () => helper.response(topicResponse));
     });
 
@@ -52,7 +52,7 @@ acceptance(
       topicResponse.post_stream.posts[1].needs_category_expert_approval = true;
       topicResponse.post_stream.posts[1].can_manage_category_expert_posts = true;
 
-      topicResponse.post_stream.posts[2].category_expert_approved = groupName;
+      topicResponse.post_stream.posts[2].category_expert_approved_group = groupName;
       topicResponse.post_stream.posts[2].can_manage_category_expert_posts = true;
 
       server.get("/t/2480.json", () => helper.response(topicResponse));

--- a/test/javascripts/acceptance/endorsement-checkboxes-test.js
+++ b/test/javascripts/acceptance/endorsement-checkboxes-test.js
@@ -1,36 +1,6 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
-
-let categories = [
-  {
-    id: 5,
-    name: "test accepting endorsements 1",
-    slug: "test-accepting-endorsements-1",
-    permission: null,
-    custom_fields: {
-      category_expert_group_ids: "1",
-      category_accepting_endorsements: "true",
-    },
-    allowingCategoryExpertEndorsements: true,
-  },
-  {
-    id: 6,
-    name: "test accepting endorsements 2",
-    slug: "test-accepting-endorsements-2",
-    permission: null,
-    custom_fields: {
-      category_expert_group_ids: "2|3",
-      category_accepting_endorsements: "true",
-    },
-    allowingCategoryExpertEndorsements: true,
-  },
-  {
-    id: 7,
-    name: "test not accepting endorsements",
-    slug: "test-not-accepting-endorsements",
-    permission: null,
-  },
-];
+import categories from "../category-expert-categories";
 
 acceptance("Discourse Category Experts - No endorsements", function (needs) {
   needs.user();

--- a/test/javascripts/category-expert-categories.js
+++ b/test/javascripts/category-expert-categories.js
@@ -1,0 +1,30 @@
+export default [
+  {
+    id: 5,
+    name: "test accepting endorsements 1",
+    slug: "test-accepting-endorsements-1",
+    permission: null,
+    custom_fields: {
+      category_expert_group_ids: "1",
+      category_accepting_endorsements: "true",
+    },
+    allowingCategoryExpertEndorsements: true,
+  },
+  {
+    id: 6,
+    name: "test accepting endorsements 2",
+    slug: "test-accepting-endorsements-2",
+    permission: null,
+    custom_fields: {
+      category_expert_group_ids: "2|3",
+      category_accepting_endorsements: "true",
+    },
+    allowingCategoryExpertEndorsements: true,
+  },
+  {
+    id: 7,
+    name: "test not accepting endorsements",
+    slug: "test-not-accepting-endorsements",
+    permission: null,
+  },
+]


### PR DESCRIPTION
With `category_experts_posts_require_approval` enabled, category expert posts have this approve button

![image](https://user-images.githubusercontent.com/16214023/110347121-e7f15500-7ff5-11eb-868f-5e5b32757193.png)

Approved posts look like this. If `category_experts_posts_require_approval` is off, category expert posts will automatically have this styling.

![image](https://user-images.githubusercontent.com/16214023/110347229-035c6000-7ff6-11eb-8886-25757982d245.png)
