### PR TITLE
Can't use JS safe navigation yet

### DIFF
--- a/assets/javascripts/discourse/helpers/category-expert-question-indicator.js
+++ b/assets/javascripts/discourse/helpers/category-expert-question-indicator.js
@@ -7,7 +7,7 @@ export function categoryExpertQuestionIndicator(topic, currentUser) {
 
   if (
     currentUser.staff ||
-    topic.creator?.id === currentUser.id ||
+    (topic.creator && topic.creator.id === currentUser.id) ||
     currentUser.expert_for_category_ids.includes(topic.category_id)
   ) {
     return htmlSafe(


### PR DESCRIPTION
@eviltrout The build fails using the `?.` operator because of uglifier. Shouldn't we be able to use it though? https://caniuse.com/?search=%3F.