### PR TITLE
Add timestamps to category_expert_endorsements

### DIFF
--- a/assets/javascripts/discourse/components/is-question-checkbox.js
+++ b/assets/javascripts/discourse/components/is-question-checkbox.js
@@ -5,7 +5,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    if (this.model.topic && this.model.topic.is_category_expert_question) {
+    if ((this.model.creatingTopic || this.model.editingFirstPost) && this.model.topic && this.model.topic.is_category_expert_question) {
       this.set("model.is_category_expert_question", true);
     }
   },

--- a/assets/javascripts/discourse/components/is-question-checkbox.js
+++ b/assets/javascripts/discourse/components/is-question-checkbox.js
@@ -5,7 +5,11 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    if ((this.model.creatingTopic || this.model.editingFirstPost) && this.model.topic && this.model.topic.is_category_expert_question) {
+    if (
+      (this.model.creatingTopic || this.model.editingFirstPost) &&
+      this.model.topic &&
+      this.model.topic.is_category_expert_question
+    ) {
       this.set("model.is_category_expert_question", true);
     }
   },

--- a/db/migrate/20210408133245_add_timestamps_to_category_experts_endorsements.rb
+++ b/db/migrate/20210408133245_add_timestamps_to_category_experts_endorsements.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToCategoryExpertsEndorsements < ActiveRecord::Migration[6.0]
+  def change
+    add_timestamps :category_expert_endorsements, null: false, default: -> { 'NOW()' }
+  end
+end


### PR DESCRIPTION
I like using this proc for `default` here. It's much cleaner than this

```ruby
def change
  add_timestamps :category_expert_endorsements, null: true 

  # update the created/upated_at columns to some date

  change_column_null :category_expert_endorsements, :created_at, false
  change_column_null :category_expert_endorsements, :updated_at, false
end
```