### PR TITLE
Allow category expert posts to be retroactively approved

### DIFF
--- a/assets/javascripts/discourse/initializers/category-experts-post-admin-menu.js
+++ b/assets/javascripts/discourse/initializers/category-experts-post-admin-menu.js
@@ -1,0 +1,67 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { createWidget } from "discourse/widgets/widget";
+import { ajax } from "discourse/lib/ajax";
+import { h } from "virtual-dom";
+import { next } from "@ember/runloop";
+
+export default {
+  name: "category-experts-post-admin-menu",
+
+  initialize(container) {
+    createWidget("category-experts-post-admin-menu-btn", {
+      tagName: "ul",
+      buildClasses: () => "category-experts-post-admin-menu-btn",
+      buildKey: () => "category-experts-post-admin-menu-btn",
+
+      defaultState() {
+        return { show: false, loading: false, loaded: false };
+      },
+
+      load(attrs, state) {
+        return ajax(`/category-experts/retroactive-approval/${attrs.id}.json`)
+          .then((response) => {
+            state.show = response.can_be_approved;
+          })
+          .catch(() => {
+            state.show = false;
+          })
+          .finally(() => {
+            state.loaded = true;
+            this.scheduleRerender();
+          });
+      },
+
+      html(attrs, state) {
+        if (
+          attrs.category_expert_approved_group ||
+          attrs.needs_category_expert_approval
+        ) {
+          return;
+        }
+        if (!state.loaded) {
+          this.load(attrs, state);
+        } else if (state.show) {
+          return this.attach("post-admin-menu-button", {
+            action: "approveCategoryExpertPost",
+            title: "category_experts.approve",
+            label: "category_experts.approve",
+            icon: "thumbs-up",
+          });
+        }
+      },
+    });
+
+    withPluginApi("0.8.36", (api) => {
+      api.decorateWidget("post-admin-menu:after", (helper) => {
+        return helper.attach(
+          "category-experts-post-admin-menu-btn",
+          helper.attrs
+        );
+      });
+      api.attachWidgetAction("post", "approveCategoryExpertPost", () => {
+        console.log("yeppers");
+        // setPostCategoryExpertAttributes(this.model, { approved: true });
+      });
+    });
+  },
+};

--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -12,13 +12,11 @@
     text-decoration: underline;
   }
 }
-.user-card .first-row .usercard-controls .category-expert-endorse-edit, .group-card .first-row .usercard-controls .category-expert-endorse-edit {
-
+.user-card .first-row .usercard-controls .category-expert-endorse-edit,
+.group-card .first-row .usercard-controls .category-expert-endorse-edit {
   width: unset;
   min-width: unset;
 }
-
-
 
 .reviewable-category-expert-suggestion {
   .reviewable-category-experts-header {
@@ -45,14 +43,15 @@
   line-height: 1em;
 }
 
-
-.time-gap+.topic-post article.category-expert-post {
-  .topic-body, .topic-avatar {
+.time-gap + .topic-post article.category-expert-post {
+  .topic-body,
+  .topic-avatar {
     border-top: 4px solid $success;
   }
 }
 article.category-expert-post {
-  .topic-body, .topic-avatar {
+  .topic-body,
+  .topic-avatar {
     border-top: 4px solid $success;
   }
 }
@@ -81,4 +80,8 @@ article.category-expert-post {
 }
 .topic-list-category-expert-question {
   background: $tertiary-low;
+}
+
+ul.category-experts-post-admin-menu-btn li {
+  border-top: 1px solid $primary-low !important;
 }

--- a/plugin.rb
+++ b/plugin.rb
@@ -255,5 +255,6 @@ after_initialize do
     put "category-experts/endorse/:username" => "category_experts#endorse", constraints: { username: ::RouteFormat.username }
     post "category-experts/approve" => "category_experts#approve_post"
     post "category-experts/unapprove" => "category_experts#unapprove_post"
+    get "category-experts/retroactive-approval/:post_id" => "category_experts#retroactive_approval?"
   end
 end

--- a/spec/requests/category_experts_controller_spec.rb
+++ b/spec/requests/category_experts_controller_spec.rb
@@ -187,7 +187,7 @@ describe CategoryExpertsController do
     end
   end
 
-  describe "#post_can_receive_retroactive_approval" do
+  describe "#retroactive_approval?" do
     fab!(:topic) { Fabricate(:topic, category: category1) }
     fab!(:random_user) { Fabricate(:user) }
 

--- a/spec/requests/category_experts_controller_spec.rb
+++ b/spec/requests/category_experts_controller_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe CategoryExpertsController do
+  fab!(:admin) { Fabricate(:admin) }
   fab!(:user) { Fabricate(:user) }
   fab!(:other_user) { Fabricate(:user) }
   fab!(:endorsee) { Fabricate(:user) }
@@ -71,7 +72,6 @@ describe CategoryExpertsController do
 
   describe "#approve_post" do
     fab!(:topic) { Fabricate(:topic, category: category1) }
-    fab!(:admin) { Fabricate(:admin) }
 
     before do
       create_post(topic_id: topic.id, user: user)
@@ -131,7 +131,6 @@ describe CategoryExpertsController do
 
   describe "#unapprove_post" do
     fab!(:topic) { Fabricate(:topic, category: category1) }
-    fab!(:admin) { Fabricate(:admin) }
 
     before do
       create_post(topic_id: topic.id, user: user)
@@ -184,6 +183,58 @@ describe CategoryExpertsController do
 
         expect(topic.reload.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]).to eq(group.name)
         expect(topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL]).to eq(false)
+      end
+    end
+  end
+
+  describe "#post_can_receive_retroactive_approval" do
+    fab!(:topic) { Fabricate(:topic, category: category1) }
+    fab!(:random_user) { Fabricate(:user) }
+
+    describe "non-staff user" do
+      before do
+        sign_in(user)
+      end
+
+      it "returns a 403" do
+        post = create_post(topic_id: topic.id, user: user)
+        get "/category-experts/retroactive-approval/#{post.id}.json"
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    describe "staff user signed in" do
+      before do
+        sign_in(admin)
+      end
+
+      it "return false when the post is not by a category expert" do
+        post = create_post(topic_id: topic.id, user: random_user)
+        get "/category-experts/retroactive-approval/#{post.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["can_be_approved"]).to eq(false)
+      end
+
+      it "returns false when the post is already marked as an expert post" do
+        post = create_post(topic_id: topic.id, user: user)
+        post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = "some-group"
+        post.save
+
+        get "/category-experts/retroactive-approval/#{post.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["can_be_approved"]).to eq(false)
+      end
+
+      it "returns the expert group name when the post can be approved" do
+        post = create_post(topic_id: topic.id, user: user)
+
+        get "/category-experts/retroactive-approval/#{post.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["can_be_approved"]).to eq(true)
       end
     end
   end


### PR DESCRIPTION
This allows staff to mark category experts posts that were created BEFORE the category settings were configured, to be marked as "approved" category expert posts.

![image](https://user-images.githubusercontent.com/16214023/114075181-e15f3300-986a-11eb-87e4-f55188c1d520.png)
