### PR TITLE
Only allow endorsement for categories that the user has access to

### DIFF
--- a/assets/javascripts/discourse/components/endorsement-button.js
+++ b/assets/javascripts/discourse/components/endorsement-button.js
@@ -57,7 +57,6 @@ export default Component.extend({
 
     showModal("endorse-user", {
       model: {
-        categories: this.categoriesAllowingEndorsements,
         user: this.user,
         endorsements: this.endorsements,
         location: this.location,

--- a/assets/javascripts/discourse/components/endorsement-checkboxes.js
+++ b/assets/javascripts/discourse/components/endorsement-checkboxes.js
@@ -13,25 +13,39 @@ export default Component.extend({
   selectedCategoryIds: null,
   startingCategoryIds: null,
   showingSuccess: false,
+  loading: true,
 
   didInsertElement() {
     this._super(...arguments);
+
     if (!this.endorsements) {
       this.set("endorsements", []);
     }
-
     this.set(
       "startingCategoryIds",
       this.endorsements.map((e) => e.category_id)
     );
-    this.set("selectedCategoryIds", [...this.startingCategoryIds]);
-    this.endorsements.forEach((endorsement) => {
-      const checkbox = this.element.querySelector(
-        `#category-endorsement-${endorsement.category_id}`
-      );
-      checkbox.checked = true;
-      checkbox.disabled = true;
-    });
+
+    ajax(`/category-experts/endorsable-categories/${this.user.username}.json`)
+      .then((response) => {
+        this.setProperties({
+          categories: response.categories,
+          selectedCategoryIds: [...this.startingCategoryIds],
+          loading: false,
+        });
+        next(() => {
+          this.endorsements.forEach((endorsement) => {
+            const checkbox = this.element.querySelector(
+              `#category-endorsement-${endorsement.category_id}`
+            );
+            if (checkbox) {
+              checkbox.checked = true;
+              checkbox.disabled = true;
+            }
+          });
+        });
+      })
+      .catch(popupAjaxError);
   },
 
   @discourseComputed("saving", "selectedCategoryIds", "startingCategoryIds")

--- a/assets/javascripts/discourse/templates/components/endorsement-checkboxes.hbs
+++ b/assets/javascripts/discourse/templates/components/endorsement-checkboxes.hbs
@@ -1,24 +1,28 @@
 {{#d-modal-body}}
   <h3>{{i18n "category_experts.manage_endorsements.subtitle" username=user.username}}</h3>
 
-  {{#if showingSuccess}}
-    <div class="endorsement-successful">
-      {{d-icon "check"}}
-    </div>
+  {{#if loading}}
+    {{loading-spinner size="large"}}
   {{else}}
-    {{#each categories as |category|}}
-      <label class="category-experts-endorsement-row">
-        <input
-          type="checkbox"
-          name="category"
-          class="category-endorsement-checkbox"
-          value={{category.id}}
-          id="category-endorsement-{{category.id}}"
-          {{action "checkboxChanged" category.id}}
-        >
-        {{category.name}}
-      </label>
-    {{/each}}
+    {{#if showingSuccess}}
+      <div class="endorsement-successful">
+        {{d-icon "check"}}
+      </div>
+    {{else}}
+      {{#each categories as |category|}}
+        <label class="category-experts-endorsement-row">
+          <input
+            type="checkbox"
+            name="category"
+            class="category-endorsement-checkbox"
+            value={{category.id}}
+            id="category-endorsement-{{category.id}}"
+            {{action "checkboxChanged" category.id}}
+          >
+          {{category.name}}
+        </label>
+      {{/each}}
+    {{/if}}
   {{/if}}
 {{/d-modal-body}}
 

--- a/assets/javascripts/discourse/templates/modal/endorse-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/endorse-user.hbs
@@ -1,5 +1,4 @@
 {{endorsement-checkboxes
-  categories=model.categories
   user=model.user
   endorsements=model.endorsements
   location=model.location

--- a/plugin.rb
+++ b/plugin.rb
@@ -256,5 +256,6 @@ after_initialize do
     post "category-experts/approve" => "category_experts#approve_post"
     post "category-experts/unapprove" => "category_experts#unapprove_post"
     get "category-experts/retroactive-approval/:post_id" => "category_experts#retroactive_approval?"
+    get "category-experts/endorsable-categories/:username" => "category_experts#endorsable_categories", constraints: { username: ::RouteFormat.username }
   end
 end

--- a/spec/requests/category_experts_controller_spec.rb
+++ b/spec/requests/category_experts_controller_spec.rb
@@ -85,7 +85,7 @@ describe CategoryExpertsController do
       end
 
       def expect_categories_in_response(response, categories)
-        category_ids = response.parsed_body["categories"].map {|c| c["id"]}.sort
+        category_ids = response.parsed_body["categories"].map { |c| c["id"] }.sort
         expect(category_ids).to eq(categories.map(&:id).sort)
       end
 
@@ -96,7 +96,6 @@ describe CategoryExpertsController do
         # Endorsee and current user cannot see the new category
         get("/category-experts/endorsable-categories/#{endorsee.username}.json")
         expect_categories_in_response(response, [category1, category2])
-
 
         # Endorsee added. Current user still cannot see the new category
         private_group.add(endorsee)

--- a/spec/requests/category_experts_controller_spec.rb
+++ b/spec/requests/category_experts_controller_spec.rb
@@ -70,6 +70,49 @@ describe CategoryExpertsController do
     end
   end
 
+  describe "#endorsable_categories" do
+    it "errors when the current user is not logged in" do
+      get("/category-experts/endorsable-categories/#{endorsee.username}.json")
+      expect(response.status).to eq(404)
+    end
+
+    context "logged in" do
+      fab!(:private_category) { fabricate_category_with_category_experts }
+      fab!(:private_group) { Fabricate(:group) }
+
+      before do
+        sign_in(user)
+      end
+
+      def expect_categories_in_response(response, categories)
+        category_ids = response.parsed_body["categories"].map {|c| c["id"]}.sort
+        expect(category_ids).to eq(categories.map(&:id).sort)
+      end
+
+      it "returns categories visible to the current user and endorsed user" do
+        private_category.set_permissions({ private_group.id => :full })
+        private_category.save
+
+        # Endorsee and current user cannot see the new category
+        get("/category-experts/endorsable-categories/#{endorsee.username}.json")
+        expect_categories_in_response(response, [category1, category2])
+
+
+        # Endorsee added. Current user still cannot see the new category
+        private_group.add(endorsee)
+
+        get("/category-experts/endorsable-categories/#{endorsee.username}.json")
+        expect_categories_in_response(response, [category1, category2])
+
+        # Both can now see the new category. It should be included
+        private_group.add(user)
+
+        get("/category-experts/endorsable-categories/#{endorsee.username}.json")
+        expect_categories_in_response(response, [category1, category2, private_category])
+      end
+    end
+  end
+
   describe "#approve_post" do
     fab!(:topic) { Fabricate(:topic, category: category1) }
 

--- a/test/javascripts/acceptance/endorsement-checkboxes-test.js
+++ b/test/javascripts/acceptance/endorsement-checkboxes-test.js
@@ -12,12 +12,19 @@ acceptance("Discourse Category Experts - No endorsements", function (needs) {
   needs.site({ categories });
 
   needs.pretender((server, helper) => {
-    // deep clone
     let cardResponse = JSON.parse(
       JSON.stringify(userFixtures["/u/charlie/card.json"])
     );
     cardResponse.user.category_expert_endorsements = [];
     server.get("/u/charlie/card.json", () => helper.response(cardResponse));
+    server.get("/category-experts/endorsable-categories/charlie.json", () =>
+      helper.response({
+        categories: [
+          { id: 517, name: "Some Category" },
+          { id: 10, name: "A different one" },
+        ],
+      })
+    );
   });
 
   test("It allows the current user to endorse another via the user card", async (assert) => {
@@ -43,7 +50,6 @@ acceptance("Discourse Category Experts - Has endorsement", function (needs) {
   needs.site({ categories });
 
   needs.pretender((server, helper) => {
-    // deep clone
     let cardResponse = JSON.parse(
       JSON.stringify(userFixtures["/u/charlie/card.json"])
     );
@@ -60,6 +66,14 @@ acceptance("Discourse Category Experts - Has endorsement", function (needs) {
       },
     ];
     server.get("/u/charlie/card.json", () => helper.response(cardResponse));
+    server.get("/category-experts/endorsable-categories/charlie.json", () =>
+      helper.response({
+        categories: [
+          { id: 517, name: "Some Category" },
+          { id: 10, name: "A different one" },
+        ],
+      })
+    );
   });
 
   test("It shows the endorse button when the current user hasn't endorsed the user yet", async (assert) => {


### PR DESCRIPTION
Right now any user can be endorsed for any category that is accepting endorsements. This was nice because it didn't require an extra call to the server, but of course cannot stand. This adds a new route that return categories that are accepting endorsements and both the logged in user, and endorsee have access to the category.