### PR TITLE
FEATURE: filter reviewable by who was endorsed

### DIFF
--- a/assets/javascripts/discourse/connectors/above-review-filters/endorsed-username-to-filters.hbs
+++ b/assets/javascripts/discourse/connectors/above-review-filters/endorsed-username-to-filters.hbs
@@ -1,0 +1,13 @@
+<div class="reviewable-filter reviewable-filter-endorsed-username-to-filter">
+  <label class="filter-label">{{i18n "review.endorsed_username"}}</label>
+  {{user-selector
+  single=true
+  fullWidthWrap=true
+  allowAny=false
+  excludeCurrentUser=false
+  includeMentionableGroups=false
+  hasGroups=false
+  usernames=additionalFilters.endorsed_username
+  autocomplete="off"
+  }}
+</div>

--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -36,6 +36,15 @@
     }
   }
 }
+
+.reviewable-container
+  .reviewable-filter-endorsed-username-to-filter
+  div.ac-wrap
+  input[type="text"] {
+  padding: 0;
+  margin: 2px 0 0px 3px;
+}
+
 .endorsement-successful {
   text-align: center;
   color: $success;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -41,3 +41,4 @@ en:
           title: "Category Expert Suggestion"
       expert-group-chooser:
         title: "Choose an expert group for the user"
+      endorsed_username: "Endorsed user"

--- a/plugin.rb
+++ b/plugin.rb
@@ -44,6 +44,19 @@ after_initialize do
 
   add_permitted_reviewable_param(:reviewable_category_expert_suggestion, :group_id)
 
+  add_custom_reviewable_filter(
+    [
+      :endorsed_username,
+      Proc.new do |results, value|
+        user_id = User.find_by_username(value)&.id
+        return results if user_id.blank?
+        results
+          .joins("INNER JOIN category_expert_endorsements ON category_expert_endorsements.id = target_id")
+          .where("category_expert_endorsements.endorsed_user_id = ?", user_id)
+      end
+    ]
+  )
+
   register_post_custom_field_type(CategoryExperts::POST_APPROVED_GROUP_NAME, :string)
   register_post_custom_field_type(CategoryExperts::POST_PENDING_EXPERT_APPROVAL, :boolean)
 


### PR DESCRIPTION
Currently, users can propose endorsement for another user. It creates a reviewable item that needs to be accepted by the admin.

When we filter by the user it returns propositions created by that specific user.

We should have another field that will allow filtering by users who will be potentially endorsed.


https://user-images.githubusercontent.com/72780/116636031-a51f7e00-a9a3-11eb-9668-074523d602b6.mov

