### PR TITLE
FIX: don't mark first post as approvable

### DIFF
--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -11,6 +11,7 @@ module CategoryExperts
 
     def process_new_post
       return unless ensure_poster_is_category_expert
+      return if post.is_first_post?
 
       SiteSetting.category_experts_posts_require_approval ?
         mark_post_for_approval :
@@ -50,7 +51,6 @@ module CategoryExperts
 
     def mark_post_as_approved
       raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
-      return if post.is_first_post?
 
       post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = users_expert_group.name
       post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = false


### PR DESCRIPTION
When Site Setting.category experts_posts_require_approval is true - first post should not be automatically approved.

When Site Setting.category experts_posts_require_approval is false - first post should not be marked as approvable.