### PR TITLE
Add site setting to approve/unapprove historical category expert posts

### DIFF
--- a/app/jobs/regular/approve_past_category_expert_posts.rb
+++ b/app/jobs/regular/approve_past_category_expert_posts.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Jobs
+  class ApprovePastCategoryExpertPosts < ::Jobs::Base
+
+    sidekiq_options queue: 'low'
+
+    def execute(args)
+      return unless SiteSetting.approve_past_posts_on_becoming_category_expert
+
+      unless args[:user_id].kind_of?(Integer)
+        raise Discourse::InvalidParameters.new(:user_id)
+      end
+
+      unless args[:category_ids].kind_of?(Array)
+        raise Discourse::InvalidParameters.new(:category_ids)
+      end
+
+      posts = Post.joins(:topic)
+        .where(user_id: args[:user_id])
+        .where(topic: { category_id: args[:category_ids] })
+
+      posts.each do |post|
+        CategoryExperts::PostHandler.new(post: post).process_new_post(skip_validations: true)
+      end
+    end
+  end
+end

--- a/app/jobs/regular/unapprove_past_category_expert_posts.rb
+++ b/app/jobs/regular/unapprove_past_category_expert_posts.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Jobs
+  class UnapprovePastCategoryExpertPosts < ::Jobs::Base
+
+    sidekiq_options queue: 'low'
+
+    def execute(args)
+      return unless SiteSetting.approve_past_posts_on_becoming_category_expert
+
+      unless args[:user_id].kind_of?(Integer)
+        raise Discourse::InvalidParameters.new(:user_id)
+      end
+
+      unless args[:category_ids].kind_of?(Array)
+        raise Discourse::InvalidParameters.new(:category_ids)
+      end
+
+      posts = Post.joins(:topic)
+        .where(user_id: args[:user_id])
+        .where(topic: { category_id: args[:category_ids] })
+
+      posts.group_by(&:topic).each do |topic, posts|
+        posts.each do |post|
+          post.custom_fields.delete(CategoryExperts::POST_APPROVED_GROUP_NAME)
+          post.custom_fields.delete(CategoryExperts::POST_PENDING_EXPERT_APPROVAL)
+          post.save
+        end
+
+        other_approved_post_count = PostCustomField
+          .where(post_id: posts.map(&:id))
+          .where(name: CategoryExperts::POST_APPROVED_GROUP_NAME)
+          .count
+
+        if other_approved_post_count == 0
+          topic.custom_fields.delete(CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES)
+          topic.save
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/regular/unapprove_past_category_expert_posts.rb
+++ b/app/jobs/regular/unapprove_past_category_expert_posts.rb
@@ -20,15 +20,15 @@ module Jobs
         .where(user_id: args[:user_id])
         .where(topic: { category_id: args[:category_ids] })
 
-      posts.group_by(&:topic).each do |topic, posts|
-        posts.each do |post|
+      posts.group_by(&:topic).each do |topic, grouped_posts|
+        grouped_posts.each do |post|
           post.custom_fields.delete(CategoryExperts::POST_APPROVED_GROUP_NAME)
           post.custom_fields.delete(CategoryExperts::POST_PENDING_EXPERT_APPROVAL)
           post.save
         end
 
         other_approved_post_count = PostCustomField
-          .where(post_id: posts.map(&:id))
+          .where(post_id: grouped_posts.map(&:id))
           .where(name: CategoryExperts::POST_APPROVED_GROUP_NAME)
           .count
 

--- a/app/jobs/regular/unapprove_past_category_expert_posts.rb
+++ b/app/jobs/regular/unapprove_past_category_expert_posts.rb
@@ -27,7 +27,6 @@ module Jobs
           post.save
         end
 
-
         other_approved_post_count = PostCustomField
           .where(post_id: topic.post_ids)
           .where(name: CategoryExperts::POST_APPROVED_GROUP_NAME)

--- a/app/jobs/regular/unapprove_past_category_expert_posts.rb
+++ b/app/jobs/regular/unapprove_past_category_expert_posts.rb
@@ -27,8 +27,9 @@ module Jobs
           post.save
         end
 
+
         other_approved_post_count = PostCustomField
-          .where(post_id: grouped_posts.map(&:id))
+          .where(post_id: topic.post_ids)
           .where(name: CategoryExperts::POST_APPROVED_GROUP_NAME)
           .count
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,6 +5,7 @@ en:
     category_experts_posts_require_approval: "Posts from category experts require staff approval for expert decoration."
     send_category_experts_reminder_pms: "Send reminder PMs to category experts, to reply to unanswered questions"
     send_admin_category_experts_posts_reminder_pm: "Send reminder PMs to staff, to review unapproved category expert posts."
+    approve_past_posts_on_becoming_category_expert: "When a user becomes an expert, all their past posts in the category are automatically approved. When a user is removed as an expert, all their posts are unapproved."
   system_messages:
     user_add_as_category_expert:
       title: "Congratulations, You are a category expert!"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,3 +12,5 @@ plugins:
     default: false
   send_admin_category_experts_posts_reminder_pm:
     default: false
+  approve_past_posts_on_becoming_category_expert:
+    default: false

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -9,16 +9,20 @@ module CategoryExperts
       @user = user || post.user
     end
 
-    def process_new_post
-      return unless ensure_poster_is_category_expert
+    def process_new_post(skip_validations: false)
+      if !skip_validations
+        return unless ensure_poster_is_category_expert
+      end
 
       SiteSetting.category_experts_posts_require_approval ?
-        mark_post_for_approval :
-        mark_post_as_approved
+        mark_post_for_approval(skip_validations: skip_validations) :
+        mark_post_as_approved(skip_validations: skip_validations)
     end
 
-    def mark_post_for_approval
-      raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
+    def mark_post_for_approval(skip_validations: false)
+      if !skip_validations
+        raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
+      end
 
       post_group_name = post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]
 
@@ -48,8 +52,10 @@ module CategoryExperts
       topic.save!
     end
 
-    def mark_post_as_approved
-      raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
+    def mark_post_as_approved(skip_validations: false)
+      if !skip_validations
+        raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
+      end
 
       post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = users_expert_group.name
       post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = false

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -12,8 +12,6 @@ describe CategoryExperts::PostHandler do
   fab!(:topic) { Fabricate(:topic, category: category) }
 
   before do
-    SiteSetting.enable_category_experts
-    SiteSetting.category_expert_suggestion_threshold
     category.custom_fields[CategoryExperts::CATEGORY_EXPERT_GROUP_IDS] = "#{group.id}|#{second_group.id}|#{group.id + 1}"
     category.save
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -72,4 +72,3 @@ describe "Adding/removing users from groups" do
     end
   end
 end
-

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "Adding/removing users from groups" do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:group) { Fabricate(:group) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+
+  before do
+    SiteSetting.approve_past_posts_on_becoming_category_expert = true
+    Jobs.run_immediately!
+    category.custom_fields[CategoryExperts::CATEGORY_EXPERT_GROUP_IDS] = group.id
+    category.save
+  end
+
+  describe "Adding user to expert group" do
+    describe "SiteSetting.category_experts_posts_require_approval = true" do
+      before do
+        SiteSetting.category_experts_posts_require_approval = true
+      end
+
+      it "marks past posts as approved" do
+        post = create_post(topic_id: topic.id, user: user)
+        group.add(user)
+        expect(topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL]).to eq(true)
+        expect(topic.first_post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL]).to eq(true)
+      end
+    end
+
+    describe "SiteSetting.category_experts_posts_require_approval = false" do
+      before do
+        SiteSetting.category_experts_posts_require_approval = false
+      end
+
+      it "marks past posts as requiring approval" do
+        post = create_post(topic_id: topic.id, user: user)
+        group.add(user)
+        expect(topic.reload.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]).to eq(group.name)
+        expect(topic.first_post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(group.name)
+      end
+    end
+  end
+
+  describe "Removing expert from group" do
+    fab!(:other_expert) { Fabricate(:user) }
+
+    before do
+      group.add(user)
+      group.add(other_expert)
+
+      post = create_post(topic_id: topic.id, user: user)
+      CategoryExperts::PostHandler.new(post: post).mark_post_as_approved
+
+      NewPostManager.new(user, raw: 'this is a new post', topic_id: topic.id).perform
+    end
+
+    it "removes past post custom fields when the expert is removed" do
+      post = topic.posts.last
+      expect(post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(group.name)
+
+      group.remove(user)
+      expect(post.reload.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(nil)
+    end
+
+    it "does not remove topic custom fields if another expert has replied" do
+      result = NewPostManager.new(other_expert, raw: 'this is a new post', topic_id: topic.id).perform
+
+      group.remove(user)
+      expect(result.post.reload.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(group.name)
+    end
+  end
+end
+

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -65,10 +65,11 @@ describe "Adding/removing users from groups" do
     end
 
     it "does not remove topic custom fields if another expert has replied" do
-      result = NewPostManager.new(other_expert, raw: 'this is a new post', topic_id: topic.id).perform
+      post = create_post(topic_id: topic.id, user: other_expert)
+      CategoryExperts::PostHandler.new(post: post).mark_post_as_approved
 
       group.remove(user)
-      expect(result.post.reload.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(group.name)
+      expect(topic.reload.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]).to eq(group.name)
     end
   end
 end


### PR DESCRIPTION
Right now, custom fields on posts and topics are saved _at the time of posting_ for category experts. This means that posts in a category by an expert, before they were in an expert group, are not marked as expert posts. The default settings capture the moment in time when the user is posting.

This setting makes it so that when you make a user a category expert, all their historical posts get the custom fields saying it's from an expert. Then to follow, then a category expert is removed as an expert, their posts _lose_ the custom fields saying they were ever from an expert.