### PR TITLE
FIX: correct return of endorsable categories

### DIFF
--- a/app/controllers/category_experts_controller.rb
+++ b/app/controllers/category_experts_controller.rb
@@ -32,11 +32,11 @@ class CategoryExpertsController < ApplicationController
     categories = Category.where(<<~SQL)
       id IN (
         SELECT cf.category_id
-        FROM category_custom_fields cf, category_custom_fields ocf
+        FROM category_custom_fields cf
+        INNER JOIN category_custom_fields ocf ON ocf.category_id = cf.category_id
+        AND ocf.name = '#{CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS}' AND ocf.value = 'true'
         WHERE cf.name = '#{CategoryExperts::CATEGORY_EXPERT_GROUP_IDS}' AND
-              cf.value <> '' AND
-              ocf.name = '#{CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS}' AND
-              ocf.value <> ''
+              cf.value <> ''
       )
     SQL
 

--- a/spec/requests/category_experts_controller_spec.rb
+++ b/spec/requests/category_experts_controller_spec.rb
@@ -21,8 +21,8 @@ describe CategoryExpertsController do
   end
 
   def enable_custom_fields_for(category)
-    category.custom_fields[CategoryExperts::CATEGORY_ACCEPTING_QUESTIONS] = true
-    category.custom_fields[CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS] = true
+    category.custom_fields[CategoryExperts::CATEGORY_ACCEPTING_QUESTIONS] = 'true'
+    category.custom_fields[CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS] = 'true'
   end
 
   def set_expert_group_for_category(category, group_ids)
@@ -79,6 +79,7 @@ describe CategoryExpertsController do
     context "logged in" do
       fab!(:private_category) { fabricate_category_with_category_experts }
       fab!(:private_group) { Fabricate(:group) }
+      fab!(:category3) { fabricate_category_with_category_experts }
 
       before do
         sign_in(user)
@@ -92,6 +93,9 @@ describe CategoryExpertsController do
       it "returns categories visible to the current user and endorsed user" do
         private_category.set_permissions({ private_group.id => :full })
         private_category.save
+
+        category3.custom_fields[CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS] = 'false'
+        category3.save
 
         # Endorsee and current user cannot see the new category
         get("/category-experts/endorsable-categories/#{endorsee.username}.json")


### PR DESCRIPTION
`category_accepting_endorsements` setting has string values like "true" or "false". Even though it was registered as :boolean because column in database is a string:

`register_category_custom_field_type(CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS, :boolean)`

Comparing <> "" was not enough to ensure that `category_accepting_endorsements` is checked

In spec I just added new category with "false" to ensure it is not added
to endorsable categories.

<img width="724" alt="Screen Shot 2021-05-26 at 2 25 44 pm" src="https://user-images.githubusercontent.com/72780/119602341-49270880-be2e-11eb-9ce1-ade2dc12ec36.png">
