### PR TITLE
FIX: do not error when private message is sent

### DIFF
--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -96,9 +96,10 @@ module CategoryExperts
 
     def users_expert_group
       return @users_expert_group if defined?(@users_expert_group) # memoizing a potentially falsy value
-      return nil if !post.topic.category
+      category = post.topic&.category
+      return if !category
 
-      group_id = user.expert_group_ids_for_category(post.topic.category)&.first
+      group_id = user.expert_group_ids_for_category(category)&.first
       @users_expert_group = group_id.nil? ? nil : Group.find_by(id: group_id)
     end
   end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -96,6 +96,7 @@ module CategoryExperts
 
     def users_expert_group
       return @users_expert_group if defined?(@users_expert_group) # memoizing a potentially falsy value
+      return nil if !post.topic.category
 
       group_id = user.expert_group_ids_for_category(post.topic.category)&.first
       @users_expert_group = group_id.nil? ? nil : Group.find_by(id: group_id)

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -10,6 +10,11 @@ describe CategoryExperts::PostHandler do
   fab!(:group) { Fabricate(:group, users: [expert]) }
   fab!(:second_group) { Fabricate(:group, users: [second_expert]) }
   fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:private_message_topic) { Fabricate(:private_message_topic, topic_allowed_users: [
+    Fabricate.build(:topic_allowed_user, user: user),
+    Fabricate.build(:topic_allowed_user, user: expert),
+    Fabricate.build(:topic_allowed_user, user: second_expert),
+  ]) }
 
   before do
     category.custom_fields[CategoryExperts::CATEGORY_EXPERT_GROUP_IDS] = "#{group.id}|#{second_group.id}|#{group.id + 1}"
@@ -29,6 +34,10 @@ describe CategoryExperts::PostHandler do
         expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID]).to eq(nil)
         expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL]).to eq(result.post.post_number)
       end
+    end
+
+    it "topic without category like private message should not error" do
+      expect { NewPostManager.new(expert, raw: 'this is a new post', topic_id: private_message_topic.id).perform }.not_to raise_error
     end
 
     describe "With an existing approved expert post" do


### PR DESCRIPTION
Bug was introduced here https://github.com/discourse/discourse-category-experts/commit/dd7fbd2f0999adf3fee234119ac299839816abb4#diff-040b0c3e0e3b0c377ccb9da72d51e1a9716135b8958e74aa81f104651972ee23R112

When private message is sent there is no category and this code was crashing