### PR TITLE
FIX: Fetch all groups for group-chooser in category settings

### DIFF
--- a/assets/javascripts/discourse/components/category-experts-settings.js
+++ b/assets/javascripts/discourse/components/category-experts-settings.js
@@ -1,30 +1,25 @@
 import Component from "@ember/component";
+import Group from "discourse/models/group";
 import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 
 export default Component.extend({
   groupIds: null,
+  allGroups: null,
 
   init() {
     this._super(...arguments);
     this.set(
       "groupIds",
       this.category.custom_fields.category_expert_group_ids
-        ? this.category.custom_fields.category_expert_group_ids.split("|")
+        ? this.category.custom_fields.category_expert_group_ids
+            .split("|")
+            .map((id) => parseInt(id, 10))
         : []
     );
 
-    ajax("/groups.json").then((response) => {
-      const groupOptions = [];
-      response.groups.forEach((group) => {
-        if (!group.automatic) {
-          groupOptions.push({
-            name: group.name,
-            id: group.id.toString(),
-          });
-        }
-      });
-      this.set("groupOptions", groupOptions);
+    Group.findAll().then((groups) => {
+      this.set("allGroups", groups.filterBy("automatic", false));
     });
 
     ajax("/badges.json").then((response) => {

--- a/assets/javascripts/discourse/templates/components/category-experts-settings.hbs
+++ b/assets/javascripts/discourse/templates/components/category-experts-settings.hbs
@@ -5,10 +5,11 @@
       {{i18n "category_experts.group"}}
     </label>
     <div class="controls">
-      {{multi-select
+      {{group-chooser
+        content=allGroups
         value=groupIds
-        content=groupOptions
-        onSelect=(action onChangeGroupIds)
+        labelProperty="name"
+        onChange=(action "onChangeGroupIds")
       }}
     </div>
   </section>


### PR DESCRIPTION
This mirrors the way the create-invite modal fetches all groups.
 
![image](https://user-images.githubusercontent.com/16214023/132714669-6306b143-3c94-483a-96e2-4ba7736fcfdb.png)
