### PR TITLE
FIX: Category link in reviewable

### DIFF
--- a/app/serializers/reviewable_category_expert_suggestion_serializer.rb
+++ b/app/serializers/reviewable_category_expert_suggestion_serializer.rb
@@ -3,9 +3,8 @@
 require_dependency 'reviewable_serializer'
 
 class ReviewableCategoryExpertSuggestionSerializer < ReviewableSerializer
-  attributes :endorsed_by, :endorsed_count, :category, :user
+  attributes :endorsed_by, :endorsed_count
 
-  has_one :category, serializer: CategorySerializer, root: false, embed: :objects
   has_one :user, serializer: BasicUserSerializer, root: false, embed: :objects
 
   def endorsed_users
@@ -27,8 +26,12 @@ class ReviewableCategoryExpertSuggestionSerializer < ReviewableSerializer
     endorsed_users.count
   end
 
-  def category
-    object.target.category
+  def category_id
+    object.target.category_id
+  end
+
+  def include_category_id?
+    true
   end
 
   def user


### PR DESCRIPTION
The front-end reviewable model converts `category_id` to a full-on category model, so no need to serialize `category`. Also, `category_id` and `include_category_id?` are defined on the base `ReviewableSerializer`, so have to override both those methods for this reviewable.

This category link is broken right now, but look here! It's fixed!
![Screen Shot 2021-11-10 at 9 24 32 AM](https://user-images.githubusercontent.com/16214023/141141836-9d3f801c-60e8-4c27-90fd-379d166ec679.png)
