### PR TITLE
DEV: Make specs a bit less brittle

### DIFF
--- a/spec/models/reviewable_category_expert_suggestion_spec.rb
+++ b/spec/models/reviewable_category_expert_suggestion_spec.rb
@@ -35,7 +35,7 @@ describe ReviewableCategoryExpertSuggestion do
       }.to change { Topic.where(archetype: Archetype.private_message).count }.by(1)
 
       expect(user.reload.group_ids).to eq([group.id])
-      expect(reviewable.status).to eq(Reviewable.statuses[:approved])
+      expect(reviewable).to be_approved
     end
 
     it "grants the user the categories badge when present" do
@@ -53,7 +53,7 @@ describe ReviewableCategoryExpertSuggestion do
       reviewable.perform(admin, :deny_category_expert)
 
       expect(user.reload.group_ids).to eq([])
-      expect(reviewable.status).to eq(Reviewable.statuses[:rejected])
+      expect(reviewable).to be_rejected
     end
   end
 end


### PR DESCRIPTION
As we’re going to use `ActiveRecord` enums instead of our current custom ones in core, we need to update some of the specs of this plugin otherwise they will break with the new changes.

(PR for core: https://github.com/discourse/discourse/pull/15330)