### PR TITLE
DEV: Create pretender for the `/category-experts/retroactive-approval/:post_id` endpoint

### DIFF
--- a/test/javascripts/helpers/category-experts-pretender.js
+++ b/test/javascripts/helpers/category-experts-pretender.js
@@ -1,0 +1,5 @@
+export default function (helper) {
+  this.get("/category-experts/retroactive-approval/:postId.json", () => {
+    return helper.response({ can_be_approved: false });
+  });
+}


### PR DESCRIPTION
This PR registers a default pretender for the `/category-experts/retroactive-approval/:post_id` endpoint which is added by this plugin and gets called when the post actions list is expanded. Without this default pretender, acceptance tests of other plugins that expand the post actions list will fail if this plugin is installed because there is nothing to handle the HTTP request made by this plugin.