### PR TITLE
FEATURE: Auto-tagging topics when experts post

### DIFF
--- a/assets/javascripts/discourse/components/category-experts-settings.js
+++ b/assets/javascripts/discourse/components/category-experts-settings.js
@@ -22,18 +22,20 @@ export default Component.extend({
       this.set("allGroups", groups.filterBy("automatic", false));
     });
 
-    ajax("/badges.json").then((response) => {
-      const badgeOptions = [];
-      response.badges.forEach((badge) => {
-        if (badge.enabled) {
-          const tempBadge = Object.assign({}, badge);
-          tempBadge.id = tempBadge.id.toString();
-          badgeOptions.push(tempBadge);
-        }
-      });
+    if (this.siteSettings.enable_badges) {
+      ajax("/badges.json").then((response) => {
+        const badgeOptions = [];
+        response.badges.forEach((badge) => {
+          if (badge.enabled) {
+            const tempBadge = Object.assign({}, badge);
+            tempBadge.id = tempBadge.id.toString();
+            badgeOptions.push(tempBadge);
+          }
+        });
 
-      this.set("badgeOptions", badgeOptions);
-    });
+        this.set("badgeOptions", badgeOptions);
+      });
+    }
   },
 
   @action

--- a/assets/javascripts/discourse/templates/components/category-experts-settings.hbs
+++ b/assets/javascripts/discourse/templates/components/category-experts-settings.hbs
@@ -14,22 +14,45 @@
     </div>
   </section>
 
-  <section class="field">
-    <label class="checkbox-label">
-      {{i18n "category_experts.badge"}}
-    </label>
-    <div class="controls">
-      <ComboBox
-        @value={{category.custom_fields.category_experts_badge_id}}
-        @content={{badgeOptions}}
-        @nameProperty="name"
-        @onChange={{action
-          (mut category.custom_fields.category_experts_badge_id)
-        }}
-        @options={{hash none="category_experts.no_badge"}}
-      />
-    </div>
-  </section>
+  {{#if siteSettings.tagging_enabled}}
+    <section class="field category-experts-auto-tagging">
+      <label class="checkbox-label">
+        {{i18n "category_experts.auto_tagging.title"}}
+      </label>
+      <div class="controls">
+        <TagChooser
+          @tags={{category.custom_fields.category_expert_auto_tag}}
+          @categoryId={{category.id}}
+          @options={{hash limit=1}}
+          @onChange={{action
+            (mut category.custom_fields.category_expert_auto_tag)
+          }}
+        />
+      </div>
+      <div class="instructions">
+        {{i18n "category_experts.auto_tagging.description"}}
+      </div>
+    </section>
+  {{/if}}
+
+  {{#if badgeOptions}}
+    <section class="field">
+      <label class="checkbox-label">
+        {{i18n "category_experts.badge"}}
+      </label>
+      <div class="controls">
+        <ComboBox
+          @value={{category.custom_fields.category_experts_badge_id}}
+          @content={{badgeOptions}}
+          @nameProperty="name"
+          @onChange={{action
+            (mut category.custom_fields.category_experts_badge_id)
+          }}
+          @options={{hash none="category_experts.no_badge"}}
+        />
+      </div>
+    </section>
+  {{/if}}
 
   {{#if category.custom_fields.category_expert_group_ids}}
     <section class="field">

--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -103,3 +103,6 @@ ul.category-experts-post-admin-menu-btn li {
 .category-experts-search-fields label {
   display: block;
 }
+.category-experts-auto-tagging .instructions {
+  font-size: var(--font-down-1);
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -16,6 +16,10 @@ en:
       approve: "Approve"
       unapprove: "Unapprove Category Expert Post"
       ask_category_expert: "Ask a category expert to respond"
+      auto_tagging:
+        title: "Automatic tagging"
+        description: "This tag will be automatically added to topics when it has an approved category expert post. Disable auto tagging by leaving the tag blank."
+
       manage_endorsements:
         title: "Endorse user"
         subtitle: "What are %{username}'s strengths?"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -18,7 +18,7 @@ en:
       ask_category_expert: "Ask a category expert to respond"
       auto_tagging:
         title: "Automatic tagging"
-        description: "This tag will be automatically added to topics when it has an approved category expert post. Disable auto tagging by leaving the tag blank."
+        description: "This tag will be automatically added to topics when an approved category expert post is created. Disable auto tagging by leaving the tag blank."
 
       manage_endorsements:
         title: "Endorse user"

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -2,10 +2,11 @@
 
 module CategoryExperts
   class PostHandler
-    attr_accessor :post, :user
+    attr_accessor :post, :topic, :user
 
     def initialize(post:, user: nil)
       @post = post
+      @topic = post.topic
       @user = user || post.user
     end
 
@@ -27,6 +28,7 @@ module CategoryExperts
       if !skip_validations
         raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
       end
+      should_remove_auto_tag = false
 
       post_group_name = post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]
 
@@ -43,7 +45,7 @@ module CategoryExperts
             value: post_group_name,
           ).exists?
 
-      unless has_accepted_posts_from_same_group
+      if !has_accepted_posts_from_same_group
         groups =
           (topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]&.split("|") || []) -
             [post_group_name]
@@ -58,11 +60,13 @@ module CategoryExperts
       if topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES].blank?
         topic.custom_fields[CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL] = post.post_number
         topic.custom_fields.delete(CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID)
+        should_remove_auto_tag = true
       else
         topic.custom_fields.delete(CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL)
       end
 
       topic.save!
+      remove_auto_tag if should_remove_auto_tag
     end
 
     def mark_post_as_approved(skip_validations: false)
@@ -86,7 +90,7 @@ module CategoryExperts
       end
 
       topic.save!
-      auto_tag_topic(topic)
+      add_auto_tag
       users_expert_group.name
     end
 
@@ -113,21 +117,38 @@ module CategoryExperts
       @users_expert_group = group_id.nil? ? nil : Group.find_by(id: group_id)
     end
 
-    def auto_tag_topic(topic)
+    def add_auto_tag
       return if !SiteSetting.tagging_enabled
-
-      auto_tag = topic.category.custom_fields[CategoryExperts::CATEGORY_EXPERT_AUTO_TAG]
-      # Return early if there is no automatic tag for the category
-      return if auto_tag.blank?
+      return if auto_tag_for_category.blank?
 
       existing_tag_names = topic.tag_names
       # Return early if the topic already has the automatic tag
-      return if existing_tag_names.include?(auto_tag)
+      return if existing_tag_names.include?(auto_tag_for_category)
 
       PostRevisor.new(topic.ordered_posts.first).revise!(
         Discourse.system_user,
-        { tags: (existing_tag_names << auto_tag) },
+        { tags: (existing_tag_names << auto_tag_for_category) },
       )
+    end
+
+    def remove_auto_tag
+      return if !SiteSetting.tagging_enabled
+      return if auto_tag_for_category.blank?
+
+      existing_tag_names = topic.tag_names
+      # Return early if the topic doesn't have the automatic tag
+      return if !existing_tag_names.include?(auto_tag_for_category)
+
+      PostRevisor.new(topic.ordered_posts.first).revise!(
+        Discourse.system_user,
+        { tags: ((existing_tag_names || []) - [auto_tag_for_category]) },
+      )
+    end
+
+    def auto_tag_for_category
+      return @auto_tag_for_category if defined?(@auto_tag_for_category)
+
+      @auto_tag_for_category = @topic.category.custom_fields[CategoryExperts::CATEGORY_EXPERT_AUTO_TAG]
     end
   end
 end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -148,7 +148,8 @@ module CategoryExperts
     def auto_tag_for_category
       return @auto_tag_for_category if defined?(@auto_tag_for_category)
 
-      @auto_tag_for_category = @topic.category.custom_fields[CategoryExperts::CATEGORY_EXPERT_AUTO_TAG]
+      @auto_tag_for_category =
+        @topic.category.custom_fields[CategoryExperts::CATEGORY_EXPERT_AUTO_TAG]
     end
   end
 end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -121,7 +121,7 @@ module CategoryExperts
       return if !SiteSetting.tagging_enabled
       return if auto_tag_for_category.blank?
 
-      existing_tag_names = topic.tag_names
+      existing_tag_names = topic.tags.map(&:name)
       # Return early if the topic already has the automatic tag
       return if existing_tag_names.include?(auto_tag_for_category)
 
@@ -135,7 +135,7 @@ module CategoryExperts
       return if !SiteSetting.tagging_enabled
       return if auto_tag_for_category.blank?
 
-      existing_tag_names = topic.tag_names
+      existing_tag_names = topic.tags.map(&:name)
       # Return early if the topic doesn't have the automatic tag
       return if !existing_tag_names.include?(auto_tag_for_category)
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,6 +29,7 @@ after_initialize do
   module ::CategoryExperts
     PLUGIN_NAME ||= "discourse-category-experts".freeze
     CATEGORY_EXPERT_GROUP_IDS = "category_expert_group_ids"
+    CATEGORY_EXPERT_AUTO_TAG = "category_expert_auto_tag"
     CATEGORY_ACCEPTING_ENDORSEMENTS = "category_accepting_endorsements"
     CATEGORY_ACCEPTING_QUESTIONS = "category_accepting_questions"
     CATEGORY_BADGE_ID = "category_experts_badge_id"
@@ -84,11 +85,13 @@ after_initialize do
   end
 
   register_category_custom_field_type(CategoryExperts::CATEGORY_EXPERT_GROUP_IDS, :string)
+  register_category_custom_field_type(CategoryExperts::CATEGORY_EXPERT_AUTO_TAG, :string)
   register_category_custom_field_type(CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS, :boolean)
   register_category_custom_field_type(CategoryExperts::CATEGORY_ACCEPTING_QUESTIONS, :boolean)
   register_category_custom_field_type(CategoryExperts::CATEGORY_BADGE_ID, :string)
 
   Site.preloaded_category_custom_fields << CategoryExperts::CATEGORY_EXPERT_GROUP_IDS
+  Site.preloaded_category_custom_fields << CategoryExperts::CATEGORY_EXPERT_AUTO_TAG
   Site.preloaded_category_custom_fields << CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS
   Site.preloaded_category_custom_fields << CategoryExperts::CATEGORY_ACCEPTING_QUESTIONS
   Site.preloaded_category_custom_fields << CategoryExperts::CATEGORY_BADGE_ID

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -144,9 +144,10 @@ describe CategoryExperts::PostHandler do
 
       it "Adds the auto tag when topic doesn't already have it" do
         expert_post = create_post(topic_id: topic.id, user: expert)
+        expert_post.topic.reload
         CategoryExperts::PostHandler.new(post: expert_post).mark_post_as_approved
 
-        expect(topic.tag_names).to include(auto_tag.name)
+        expect(topic.reload.tag_names).to include(auto_tag.name)
       end
     end
 

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -155,6 +155,8 @@ describe CategoryExperts::PostHandler do
         post = create_post(topic_id: topic.id, user: expert)
         expect(topic.tags.map(&:name)).to include(auto_tag.name)
 
+        # Have to reload, otherwise `PostRevisor` changes aren't picked up
+        post.topic.reload
         CategoryExperts::PostHandler.new(post: post).mark_post_for_approval
 
         expect(topic.reload.tags.map(&:name)).not_to include(auto_tag.name)

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -144,10 +144,9 @@ describe CategoryExperts::PostHandler do
 
       it "Adds the auto tag when topic doesn't already have it" do
         expert_post = create_post(topic_id: topic.id, user: expert)
-        expert_post.topic.reload
         CategoryExperts::PostHandler.new(post: expert_post).mark_post_as_approved
 
-        expect(topic.reload.tag_names).to include(auto_tag.name)
+        expect(topic.reload.tags.map(&:name)).to include(auto_tag.name)
       end
     end
 

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -9,7 +9,8 @@ describe CategoryExperts::PostHandler do
   fab!(:category) { Fabricate(:category) }
   fab!(:group) { Fabricate(:group, users: [expert]) }
   fab!(:second_group) { Fabricate(:group, users: [second_expert]) }
-  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:tag) { Fabricate(:tag) }
+  fab!(:topic) { Fabricate(:topic, category: category, tags: [tag]) }
   fab!(:private_message_topic) do
     Fabricate(
       :private_message_topic,
@@ -121,6 +122,30 @@ describe CategoryExperts::PostHandler do
       expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]).to eq(
         "#{group.name}|#{second_group.name}",
       )
+    end
+  end
+
+  describe "Auto tagging" do
+    fab!(:auto_tag) { Fabricate(:tag) }
+
+    before do
+      category.custom_fields[CategoryExperts::CATEGORY_EXPERT_AUTO_TAG] = auto_tag.name
+      category.save!
+    end
+
+    it "Doesn't error when the auto tag is already present on the topic" do
+      post = create_post(topic_id: topic.id, user: user)
+      PostRevisor.new(post).revise!(Discourse.system_user, tags: [auto_tag.name])
+
+      expert_post = create_post(topic_id: topic.id, user: expert)
+      CategoryExperts::PostHandler.new(post: expert_post).mark_post_as_approved
+    end
+
+    it "Adds the auto tag when topic doesn't already have it" do
+      expert_post = create_post(topic_id: topic.id, user: expert)
+      CategoryExperts::PostHandler.new(post: expert_post).mark_post_as_approved
+
+      expect(topic.tag_names).to include(auto_tag.name)
     end
   end
 end


### PR DESCRIPTION
There was a request to have topic automatically tagged with a specific tag, when a post has an approved category expert post. This adds a setting in the category configuration for category experts, to specify the tag.

![Screenshot 2023-05-10 at 9 56 23 AM](https://github.com/discourse/discourse-category-experts/assets/16214023/0f1cfaf9-1c90-4416-88b3-a502da918c14)
-4e9c-99d5-49df240c3355)
