### PR TITLE
DEV: Use rspec `to include` so that tests can show the actual raw for debugging

### DIFF
--- a/spec/jobs/remind_category_experts_job_spec.rb
+++ b/spec/jobs/remind_category_experts_job_spec.rb
@@ -49,15 +49,15 @@ describe CategoryExperts::RemindCategoryExpertsJob do
     split_raw = expert1_message.first_post.raw.split("\n")
 
     expect(split_raw.count).to eq(2)
-    expect(split_raw.first.include?("There are [2 unanswered")).to eq(true)
-    expect(split_raw.second.include?("There are [1 unanswered")).to eq(true)
+    expect(split_raw.first).to include("There are [2 unanswered")
+    expect(split_raw.second).to include("There are [1 unanswered")
 
     # Expert 2 should only get 1 row
     expert2_message = expert2.topics_allowed.where(archetype: Archetype.private_message).last
     split_raw = expert2_message.first_post.raw.split("\n")
 
     expect(split_raw.count).to eq(1)
-    expect(split_raw.first.include?("There are [2 unanswered")).to eq(true)
+    expect(split_raw.first).to include("There are [2 unanswered")
   end
 
   it "Does nothing if the site setting is disabled" do


### PR DESCRIPTION
We want to see 

```
0) CategoryExperts::RemindCategoryExpertsJob Sends out the correct PM to each category expert
     Failure/Error: expect(split_raw.first).to include("There are [1 unanswered")
       expected "There are [2 unanswered questions] for a category expert in the category [Amazing Category 0](/c/amazing-category-0/1918)." to include "There are [1 unanswered"
```

instead of 

```
 1) CategoryExperts::RemindCategoryExpertsJob Sends out the correct PM to each category expert
     Failure/Error: expect(split_raw.first.include?("There are [2 unanswered")).to eq(true)

       expected: true
            got: false

       (compared using ==)
```