### PR TITLE
Add setting to include/exclude OP when adding Expert highlighting.

### DIFF
--- a/assets/javascripts/discourse/helpers/category-expert-topic-list-indicators.js
+++ b/assets/javascripts/discourse/helpers/category-expert-topic-list-indicators.js
@@ -22,7 +22,7 @@ export function categoryExpertTopicListIndicators(context) {
 
 const addApprovedPills = (topic, siteSettings) => {
   let html = "";
-  (topic.expert_post_group_names || []).forEach((groupName) => {
+  siteSettings.first_post_can_be_considered_expert_post && (topic.expert_post_group_names || []).forEach((groupName) => {
     const href = siteSettings.category_experts_topic_list_link_to_posts
       ? `${topic.url}/${topic.first_expert_post_id}`
       : "/search?q=with:category_expert_response";

--- a/assets/javascripts/discourse/helpers/category-expert-topic-list-indicators.js
+++ b/assets/javascripts/discourse/helpers/category-expert-topic-list-indicators.js
@@ -4,7 +4,6 @@ import { htmlSafe } from "@ember/template";
 
 export function categoryExpertTopicListIndicators(context) {
   let html = "";
-
   html += addApprovedPills(context.topic, context.siteSettings);
   html += addNeedsApprovalPill(
     context.topic,
@@ -22,7 +21,7 @@ export function categoryExpertTopicListIndicators(context) {
 
 const addApprovedPills = (topic, siteSettings) => {
   let html = "";
-  siteSettings.first_post_can_be_considered_expert_post && (topic.expert_post_group_names || []).forEach((groupName) => {
+  (topic.expert_post_group_names || []).forEach((groupName) => {
     const href = siteSettings.category_experts_topic_list_link_to_posts
       ? `${topic.url}/${topic.first_expert_post_id}`
       : "/search?q=with:category_expert_response";

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,7 @@
 en:
   site_settings:
     enable_category_experts: "Enable category experts plugin"
+    first_post_can_be_considered_expert_post: "First post can be considered expert post"
     show_category_expert_advanced_search_filters: "Show category expert filters in advanced search"
     category_expert_suggestion_threshold: "Suggest category experts after this many endorsements."
     category_experts_posts_require_approval: "Posts from category experts require staff approval for expert decoration."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,9 @@ plugins:
   enable_category_experts:
     default: true
     client: true
+  first_post_can_be_considered_expert_post:
+    default: false
+    client: true
   show_category_expert_advanced_search_filters:
     default: true
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,6 @@ plugins:
     client: true
   first_post_can_be_considered_expert_post:
     default: false
-    client: true
   show_category_expert_advanced_search_filters:
     default: true
     client: true

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -75,25 +75,24 @@ module CategoryExperts
       end
 
       # if this is not the topic post (post>1) OR it's the topic post/first post and it's ok for that to be an expert post
-      if post.post_number > 1 || SiteSetting.first_post_can_be_considered_expert_post
-        post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = users_expert_group.name
-        post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = false
-        post.save!
+      return unless post.post_number > 1 || SiteSetting.first_post_can_be_considered_expert_post
 
-        topic = post.topic
-        topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES] = (
-          topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]&.split("|") || []
-        ).push(users_expert_group.name).uniq.join("|")
-        topic.custom_fields.delete(CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL)
+      post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = users_expert_group.name
+      post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = false
+      post.save!
 
-        if !topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID] ||
-             topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID] == 0
-          topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID] = post.post_number
-        end
+      topic = post.topic
+      topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES] = (
+        topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]&.split("|") || []
+      ).push(users_expert_group.name).uniq.join("|")
+      topic.custom_fields.delete(CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL)
 
-        topic.save!
+      if !topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID] ||
+           topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID] == 0
+        topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID] = post.post_number
       end
 
+      topic.save!
       add_auto_tag
       users_expert_group.name
     end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -75,7 +75,7 @@ module CategoryExperts
       end
 
       # if this is not the topic post (post>1) OR it's the topic post/first post and it's ok for that to be an expert post
-      if post.post_number>1 || SiteSetting.first_post_can_be_considered_expert_post
+      if post.post_number > 1 || SiteSetting.first_post_can_be_considered_expert_post
         post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = users_expert_group.name
         post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = false
         post.save!

--- a/spec/jobs/correct_historical_category_expert_posts_spec.rb
+++ b/spec/jobs/correct_historical_category_expert_posts_spec.rb
@@ -29,6 +29,7 @@ describe Jobs::CorrectHistoricalCategoryExpertPosts do
     SiteSetting.enable_category_experts = true
     SiteSetting.category_experts_posts_require_approval = false
     SiteSetting.approve_past_posts_on_becoming_category_expert = true
+    SiteSetting.first_post_can_be_considered_expert_post = true
     Jobs.run_immediately!
   end
 

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -30,10 +30,10 @@ describe CategoryExperts::PostHandler do
   end
 
   describe "SiteSetting.category_experts_posts_require_approval enabled" do
-    before {
+    before do
       SiteSetting.category_experts_posts_require_approval = true
       SiteSetting.first_post_can_be_considered_expert_post = true
-    }
+    end
 
     describe "No existing approved expert posts" do
       it "marks the post as needing approval, as well as the topic" do
@@ -94,10 +94,10 @@ describe CategoryExperts::PostHandler do
   end
 
   describe "SiteSetting.category_experts_posts_require_approval disabled" do
-    before {
+    before do
       SiteSetting.category_experts_posts_require_approval = false
       SiteSetting.first_post_can_be_considered_expert_post = true
-    }
+    end
 
     it "marks posts as approved automatically" do
       result = NewPostManager.new(expert, raw: "this is a new post", topic_id: topic.id).perform
@@ -181,39 +181,30 @@ describe CategoryExperts::PostHandler do
   end
 
   describe "SiteSetting.first_post_can_be_considered_expert_post false" do
-    before {
+    before do
       SiteSetting.category_experts_posts_require_approval = false
       SiteSetting.first_post_can_be_considered_expert_post = false
-    }
+    end
 
     it "adds expert group names to the topic custom fields on second post, but not first post" do
       post = create_post(topic_id: topic.id, user: expert)
       CategoryExperts::PostHandler.new(post: post).mark_post_as_approved
-      expect(post.topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]).to eq(
-                                                                                            nil,
-                                                                                            )
+      expect(post.topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]).to eq(nil)
 
       result =
         NewPostManager.new(second_expert, raw: "this is a new post", topic_id: topic.id).perform
       expect(result.post.topic.custom_fields[CategoryExperts::TOPIC_EXPERT_POST_GROUP_NAMES]).to eq(
-                                                                                                   second_group.name,
-                                                                                                   )
+        second_group.name,
+      )
     end
 
     it "adds expert group names to the post custom fields on second post, but not first post" do
       post = create_post(topic_id: topic.id, user: expert)
       CategoryExperts::PostHandler.new(post: post).mark_post_as_approved
-      expect(post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(
-                                                                                            nil,
-                                                                                            )
+      expect(post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(nil)
 
-      result =
-        NewPostManager.new(expert, raw: "this is a new post", topic_id: topic.id).perform
-      expect(result.post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(
-                                                                                            group.name,
-                                                                                                   )
+      result = NewPostManager.new(expert, raw: "this is a new post", topic_id: topic.id).perform
+      expect(result.post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(group.name)
     end
-
   end
-
 end

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -137,6 +137,7 @@ describe CategoryExperts::PostHandler do
     before do
       category.custom_fields[CategoryExperts::CATEGORY_EXPERT_AUTO_TAG] = auto_tag.name
       category.save!
+      SiteSetting.first_post_can_be_considered_expert_post = true
     end
 
     describe "Adding" do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -32,7 +32,10 @@ describe Group do
     end
 
     describe "SiteSetting.category_experts_posts_require_approval = false" do
-      before { SiteSetting.category_experts_posts_require_approval = false }
+      before {
+        SiteSetting.category_experts_posts_require_approval = false
+        SiteSetting.first_post_can_be_considered_expert_post = true
+      }
 
       it "marks past posts as requiring approval" do
         post = create_post(topic_id: topic.id, user: user)

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -32,10 +32,10 @@ describe Group do
     end
 
     describe "SiteSetting.category_experts_posts_require_approval = false" do
-      before {
+      before do
         SiteSetting.category_experts_posts_require_approval = false
         SiteSetting.first_post_can_be_considered_expert_post = true
-      }
+      end
 
       it "marks past posts as requiring approval" do
         post = create_post(topic_id: topic.id, user: user)

--- a/spec/requests/category_experts_controller_spec.rb
+++ b/spec/requests/category_experts_controller_spec.rb
@@ -215,6 +215,7 @@ describe CategoryExpertsController do
       before do
         sign_in(admin)
         SiteSetting.category_experts_posts_require_approval = true
+        SiteSetting.first_post_can_be_considered_expert_post = true
       end
 
       it "approves the post and returns the expert group name" do
@@ -280,6 +281,7 @@ describe CategoryExpertsController do
       before do
         sign_in(admin)
         SiteSetting.category_experts_posts_require_approval = true
+        SiteSetting.first_post_can_be_considered_expert_post = true
       end
 
       it "unapproves the post and returns the expert group name" do


### PR DESCRIPTION
adds site setting, `first_post_can_be_considered_expert_post`, which defaults to false.

left as default, this setting prevents the situation of an expert posting a topic that is immediately marked as having an "expert response", despite there being no replies at all, let alone an expert reply.

details: https://dev.discourse.org/t/sailpoint-category-experts-exclude-first-poster/105541

