### PR TITLE
FIX: Category expert approval in modal

### DIFF
--- a/assets/javascripts/discourse/components/modal/expert-group-chooser.js
+++ b/assets/javascripts/discourse/components/modal/expert-group-chooser.js
@@ -9,13 +9,13 @@ export default class ExpertGroupChooserModal extends Component {
 
   @action
   loadGroups() {
-    const groupIds =
+    const expertGroupIds =
       this.args.model.reviewable.category.custom_fields.category_expert_group_ids.split(
         "|"
       );
     ajax("/groups.json").then((response) => {
-      this.groupOptions = response.groups.filter((g) =>
-        groupIds.includes(g.id.toString())
+      this.groupOptions = response.groups.filter((group) =>
+        expertGroupIds.includes(group.id.toString())
       );
     });
   }
@@ -24,6 +24,6 @@ export default class ExpertGroupChooserModal extends Component {
   setGroupId(val) {
     this.args.model.reviewable.set("group_id", val);
     this.args.closeModal();
-    this.args.model.performConfirmed(this.action);
+    this.args.model.performConfirmed(this.args.model.action);
   }
 }

--- a/spec/fabricators/category_expert_fabricators.rb
+++ b/spec/fabricators/category_expert_fabricators.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Fabricator(:category_expert_endorsement) do
+  user
+  category
+  endorsed_user { Fabricate(:user) }
+end
+
+Fabricator(:reviewable_category_expert_suggestion) do
+  reviewable_by_moderator false
+  type "ReviewableCategoryExpertSuggestion"
+  created_by { Fabricate(:user) }
+  topic
+  target_type "CategoryExpertEndorsement"
+  target { Fabricate(:category_expert_endorsement) }
+end

--- a/spec/system/reviewable_category_expert_suggestion_spec.rb
+++ b/spec/system/reviewable_category_expert_suggestion_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe "Reviewables - Category expert suggestion", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:other_user) { Fabricate(:user) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:group) { Fabricate(:group) }
+  let(:modal) { PageObjects::Modals::Base.new }
+
+  before do
+    SiteSetting.enable_category_experts = true
+    SiteSetting.category_expert_suggestion_threshold = 1
+
+    sign_in(current_user)
+    category.custom_fields[CategoryExperts::CATEGORY_EXPERT_GROUP_IDS] = group.id.to_s
+    category.custom_fields[CategoryExperts::CATEGORY_ACCEPTING_ENDORSEMENTS] = "true"
+    category.save!
+  end
+
+  it "can endorse users as category experts to place them in the review queue" do
+    visit "/u/#{other_user.username_lower}"
+
+    find(".category-expert-endorse-btn").click
+    find(".category-endorsement-checkbox").click
+    modal.click_primary_button
+
+    expect(page).to have_content(I18n.t("js.category_experts.existing_endorsements", count: 1))
+
+    reviewable = ReviewableCategoryExpertSuggestion.find_by(created_by: current_user)
+    expect(reviewable.status).to eq("pending")
+    expect(reviewable.target_type).to eq("CategoryExpertEndorsement")
+  end
+
+  context "as an admin reviewing endorsements" do
+    fab!(:current_user) { Fabricate(:admin) }
+
+    it "can approve an endorsement" do
+      endorsement =
+        Fabricate(:category_expert_endorsement, category: category, endorsed_user: other_user)
+      visit "/review"
+
+      reviewable = ReviewableCategoryExpertSuggestion.find_by(target: endorsement)
+      expect(page).to have_css(".reviewable-item[data-reviewable-id=\"#{reviewable.id}\"]")
+
+      find(".reviewable-action.approve-category-expert").click
+      expect(modal).to have_content(group.name)
+      find("#tap_tile_#{group.id}").click
+      expect(page).to have_content(I18n.t("js.review.none"), wait: 5)
+      expect(reviewable.reload.status).to eq("approved")
+    end
+
+    it "can reject an endorsement" do
+      endorsement =
+        Fabricate(:category_expert_endorsement, category: category, endorsed_user: other_user)
+      visit "/review"
+
+      reviewable = ReviewableCategoryExpertSuggestion.find_by(target: endorsement)
+      expect(page).to have_css(".reviewable-item[data-reviewable-id=\"#{reviewable.id}\"]")
+
+      find(".reviewable-action.deny-category-expert").click
+      expect(page).to have_content(I18n.t("js.review.none"), wait: 5)
+      expect(reviewable.reload.status).to eq("rejected")
+    end
+  end
+end


### PR DESCRIPTION
Since a04991e0a2370f65c5d22a4c7f8b10e6b569b235 the
approval/confirmation button in the Approve action for
category expert endorsements has been broken; this.action
was used instead of this.args.model.action.

This commit fixes the issue and adds initial system specs
for the category experts functionality.
