### PR TITLE
FIX: Amend failing reviewable system test selector

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -29,7 +29,7 @@ en:
         title: "Endorse user"
         subtitle: "What are %{username}'s strengths?"
       review:
-        approve: "Approve..."
+        approve: "Approve"
         deny: "Ignore"
         endorsed_count:
           one: "has been endorsed %{count} time for "

--- a/spec/system/reviewable_category_expert_suggestion_spec.rb
+++ b/spec/system/reviewable_category_expert_suggestion_spec.rb
@@ -42,7 +42,7 @@ describe "Reviewables - Category expert suggestion", type: :system, js: true do
       reviewable = ReviewableCategoryExpertSuggestion.find_by(target: endorsement)
       expect(page).to have_css(".reviewable-item[data-reviewable-id=\"#{reviewable.id}\"]")
 
-      find(".reviewable-action.approve-category-expert").click
+      find(".reviewable-action", text: /Approve/).click
       expect(modal).to have_content(group.name)
       find("#tap_tile_#{group.id}").click
       expect(page).to have_content(I18n.t("js.review.none"), wait: 5)
@@ -57,7 +57,7 @@ describe "Reviewables - Category expert suggestion", type: :system, js: true do
       reviewable = ReviewableCategoryExpertSuggestion.find_by(target: endorsement)
       expect(page).to have_css(".reviewable-item[data-reviewable-id=\"#{reviewable.id}\"]")
 
-      find(".reviewable-action.deny-category-expert").click
+      find(".reviewable-action", text: /Ignore/).click
       expect(page).to have_content(I18n.t("js.review.none"), wait: 5)
       expect(reviewable.reload.status).to eq("rejected")
     end


### PR DESCRIPTION
### What is this change?

This system test is failing in core after some changes to the review queue.

This PR fixes that by relying on the text of the button instead of a class name. This should be backwards compatible since the content hasn't change, and arguably a little bit more clear and a little bit more stable than relying on the class name.