### PR TITLE
FIX: Endorsement reviewable text & endorsement checkboxes

### DIFF
--- a/assets/javascripts/discourse/components/modal/endorse-user/endorsement-checkboxes.hbs
+++ b/assets/javascripts/discourse/components/modal/endorse-user/endorsement-checkboxes.hbs
@@ -19,15 +19,17 @@
       {{else}}
         {{#each categories as |category|}}
           <label class="category-experts-endorsement-row">
-            <input
-              type="checkbox"
+            <Input
+              @type="checkbox"
+              @checked={{this.isChecked category.id}}
+              {{on
+                "change"
+                (fn this.checkboxChanged category.id)
+              }}
+              disabled={{this.isDisabled category.id}}
               name="category"
               class="category-endorsement-checkbox"
-              value={{category.id}}
               id="category-endorsement-{{category.id}}"
-              {{action "checkboxChanged" category.id}}
-              checked={{this.isChecked category.id}}
-              disabled={{this.isDisabled category.id}}
             />
             {{category.name}}
           </label>

--- a/assets/javascripts/discourse/components/modal/endorse-user/endorsement-checkboxes.hbs
+++ b/assets/javascripts/discourse/components/modal/endorse-user/endorsement-checkboxes.hbs
@@ -22,10 +22,7 @@
             <Input
               @type="checkbox"
               @checked={{this.isChecked category.id}}
-              {{on
-                "change"
-                (fn this.checkboxChanged category.id)
-              }}
+              {{on "change" (fn this.checkboxChanged category.id)}}
               disabled={{this.isDisabled category.id}}
               name="category"
               class="category-endorsement-checkbox"

--- a/assets/javascripts/discourse/components/reviewable-category-expert-suggestion.js
+++ b/assets/javascripts/discourse/components/reviewable-category-expert-suggestion.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default class ReviewableCategoryExpertSuggestion extends Component {}

--- a/assets/javascripts/discourse/components/reviewable-category-expert-suggestions.js
+++ b/assets/javascripts/discourse/components/reviewable-category-expert-suggestions.js
@@ -1,3 +1,0 @@
-import Component from "@ember/component";
-
-export default class ReviewableCategoryExpertSuggestions extends Component {}


### PR DESCRIPTION
Before: Endorsement reviewable had an interface error: 
![image](https://github.com/discourse/discourse-category-experts/assets/70915823/e204bc15-f2ef-4d42-9409-eff6c77faee5)
After: It shows relevant information:
![image](https://github.com/discourse/discourse-category-experts/assets/70915823/bac0a9d0-9c83-42c0-a391-b08733c577fd)

Before: The checkbox on Endorse User modal did not show the click state:
![image](https://github.com/discourse/discourse-category-experts/assets/70915823/6dd3f33b-427f-483d-b1f5-49cb3e73e1c3)
After: It shows click state:
![image](https://github.com/discourse/discourse-category-experts/assets/70915823/9fd3877d-79b5-49e3-a3fb-8d4eff7e6b01)

