### PR TITLE
UX: Add Space between 'Close' and 'Ask a category expert to respond

### DIFF
--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -106,3 +106,7 @@ ul.category-experts-post-admin-menu-btn li {
 .category-experts-auto-tagging .instructions {
   font-size: var(--font-down-1);
 }
+.is-category-expert-question {
+  margin-bottom: 0;
+  margin-left: 1em;
+}


### PR DESCRIPTION
Before: There was no space after "Close":
<img width="1440" alt="Screenshot 2024-05-13 at 4 11 51 PM" src="https://github.com/discourse/discourse-category-experts/assets/70915823/252efe73-37f7-4228-a7fb-e5aa19913a6f">
After: Added space after "Close":
<img width="1440" alt="Screenshot 2024-05-14 at 10 05 02 AM" src="https://github.com/discourse/discourse-category-experts/assets/70915823/5898c7cc-2ba4-47c2-b304-45a41f2ceca5">
