### PR TITLE
FEATURE: Added Category Experts approved WebHook Event

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5,6 +5,11 @@ en:
         categories:
           discourse_category_experts: "Discourse Category Experts"
   js:
+    admin:
+      web_hooks:
+        category_experts_event:
+          group_name: "Category experts event"
+          category_experts_approved: "Post approved by category experts"
     category_experts:
       title: "Category Experts"
       group: "Category experts group"

--- a/lib/category_experts/outgoing_web_hook_extension.rb
+++ b/lib/category_experts/outgoing_web_hook_extension.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module CategoryExperts
+  module OutgoingWebHookExtension
+    def self.prepended(base)
+      def base.enqueue_category_experts_hooks(event, post, payload = nil)
+        if active_web_hooks(event).exists?
+          payload ||= WebHook.generate_payload(:post, post)
+
+          WebHook.enqueue_hooks(
+            :category_experts,
+            event,
+            id: post.id,
+            category_id: post.topic&.category_id,
+            tag_ids: post.topic&.tags&.pluck(:id),
+            payload: payload,
+          )
+        end
+      end
+    end
+  end
+end
+
+# module DiscourseSolved::WebHookExtension
+#   extend ActiveSupport::Concern
+
+#   class_methods do
+#     def enqueue_solved_hooks(event, post, payload = nil)
+#       if active_web_hooks(event).exists? && post.present?
+#         payload ||= WebHook.generate_payload(:post, post)
+
+#         WebHook.enqueue_hooks(
+#           :solved,
+#           event,
+#           id: post.id,
+#           category_id: post.topic&.category_id,
+#           tag_ids: post.topic&.tags&.pluck(:id),
+#           payload: payload,
+#         )
+#       end
+#     end

--- a/lib/category_experts/outgoing_web_hook_extension.rb
+++ b/lib/category_experts/outgoing_web_hook_extension.rb
@@ -20,22 +20,3 @@ module CategoryExperts
     end
   end
 end
-
-# module DiscourseSolved::WebHookExtension
-#   extend ActiveSupport::Concern
-
-#   class_methods do
-#     def enqueue_solved_hooks(event, post, payload = nil)
-#       if active_web_hooks(event).exists? && post.present?
-#         payload ||= WebHook.generate_payload(:post, post)
-
-#         WebHook.enqueue_hooks(
-#           :solved,
-#           event,
-#           id: post.id,
-#           category_id: post.topic&.category_id,
-#           tag_ids: post.topic&.tags&.pluck(:id),
-#           payload: payload,
-#         )
-#       end
-#     end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -94,7 +94,6 @@ module CategoryExperts
 
       topic.save!
 
-      puts "Triggering category_expert_approved event"
       DiscourseEvent.trigger(:category_experts_approved, post)
 
       add_auto_tag

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -93,6 +93,10 @@ module CategoryExperts
       end
 
       topic.save!
+
+      puts "Triggering category_expert_approved event"
+      DiscourseEvent.trigger(:category_experts_approved, post)
+
       add_auto_tag
       users_expert_group.name
     end

--- a/spec/fabricators/outgoing_category_experts_web_hook_fabricator.rb
+++ b/spec/fabricators/outgoing_category_experts_web_hook_fabricator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Fabricator(:outgoing_category_experts_web_hook, from: :web_hook) do
+  payload_url "https://meta.discourse.org/webhook_listener"
+  content_type WebHook.content_types["application/json"]
+  wildcard_web_hook false
+  secret "my_lovely_secret_for_web_hook"
+  verify_certificate true
+  active true
+
+  after_build do |web_hook|
+    web_hook.web_hook_event_types = WebHookEventType.where(name: %w[category_experts_approved])
+  end
+end

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "webmock/rspec"
 
 describe CategoryExperts::PostHandler do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
@@ -89,18 +90,6 @@ describe CategoryExperts::PostHandler do
             ],
           ).count
         }
-      end
-    end
-
-    describe "marking post as approved" do
-      it "triggers a Discourse event" do
-        post = create_post(topic_id: topic.id, user: expert)
-
-        DiscourseEvent.expects(:trigger).with(
-          :category_experts_approved,
-          instance_of(CategoryExperts::PostHandler.new(post: post).mark_post_as_approved),
-          post,
-        )
       end
     end
   end
@@ -218,6 +207,31 @@ describe CategoryExperts::PostHandler do
 
       result = NewPostManager.new(expert, raw: "this is a new post", topic_id: topic.id).perform
       expect(result.post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]).to eq(group.name)
+    end
+  end
+
+  describe "Webhook integration" do
+    fab!(:webhook) { Fabricate(:outgoing_category_experts_web_hook) }
+
+    before do
+      SiteSetting.category_experts_posts_require_approval = true
+      SiteSetting.first_post_can_be_considered_expert_post = true
+
+      stub_request(:post, webhook.payload_url)
+      Jobs.run_immediately!
+    end
+
+    it "sends a webhook event when a post is approved" do
+      post = create_post(topic_id: topic.id, user: expert)
+      CategoryExperts::PostHandler.new(post: post).mark_post_as_approved
+
+      expect(WebMock).to have_requested(:post, webhook.payload_url)
+        .with { |req|
+          json = JSON.parse(req.body)
+          req.headers["X-Discourse-Event"] == "category_experts_approved" &&
+            json.dig("category_experts", "id") == post.id
+        }
+        .once
     end
   end
 end

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -91,6 +91,18 @@ describe CategoryExperts::PostHandler do
         }
       end
     end
+
+    describe "marking post as approved" do
+      it "triggers a Discourse event" do
+        post = create_post(topic_id: topic.id, user: expert)
+
+        DiscourseEvent.expects(:trigger).with(
+          :category_experts_approved,
+          instance_of(CategoryExperts::PostHandler.new(post: post).mark_post_as_approved),
+          post,
+        )
+      end
+    end
   end
 
   describe "SiteSetting.category_experts_posts_require_approval disabled" do


### PR DESCRIPTION
### Changes 

This PR is adding a WebHook Event for the post that is approved by the Category Experts.

This is the screenshot for the Category Experts approved webhook event option:
<img width="912" alt="Screenshot 2024-08-24 at 7 33 12 AM" src="https://github.com/user-attachments/assets/1dcaa13c-cfa5-4669-8382-df204b442ed6">

And this is the screenshot for the Webbhook events after the post got approved by a Category Expert:
<img width="1000" alt="Screenshot 2024-08-24 at 7 31 37 AM" src="https://github.com/user-attachments/assets/8df72cc6-272b-45cf-9a53-67846e504fd0">
