### PR TITLE
DEV: Approved Post Webhook Event Payload Update

### DIFF
--- a/lib/category_experts/outgoing_web_hook_extension.rb
+++ b/lib/category_experts/outgoing_web_hook_extension.rb
@@ -8,7 +8,7 @@ module CategoryExperts
           payload ||= WebHook.generate_payload(:post, post)
 
           WebHook.enqueue_hooks(
-            :category_experts,
+            :post,
             event,
             id: post.id,
             category_id: post.topic&.category_id,

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -229,7 +229,7 @@ describe CategoryExperts::PostHandler do
         .with { |req|
           json = JSON.parse(req.body)
           req.headers["X-Discourse-Event"] == "category_experts_approved" &&
-            json.dig("category_experts", "id") == post.id
+            json.dig("post", "id") == post.id
         }
         .once
     end


### PR DESCRIPTION
### Changes 

Approved post Webhook event payload header will have 'X-Discourse-Event-Type: post':

<img width="1151" alt="Screenshot 2024-09-04 at 12 55 24 PM" src="https://github.com/user-attachments/assets/31cfc608-6864-4827-bbf2-eeb2b2cc3eb6">
