### PR TITLE
FEATURE: Added Category Experts unapproved post WebHook Event

### DIFF
--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -66,6 +66,9 @@ module CategoryExperts
       end
 
       topic.save!
+
+      DiscourseEvent.trigger(:category_experts_unapproved, post)
+
       remove_auto_tag if should_remove_auto_tag
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -347,10 +347,12 @@ after_initialize do
   end
 
   # outgoing webhook events
-  on(:category_experts_approved) do |post|
-    if WebHook.active_web_hooks(:category_experts_approved).exists?
-      payload = WebHook.generate_payload(:post, post)
-      WebHook.enqueue_category_experts_hooks(:category_experts_approved, post, payload)
+  %i[category_experts_approved category_experts_unapproved].each do |category_experts_event|
+    on(category_experts_event) do |post|
+      if WebHook.active_web_hooks(category_experts_event).exists?
+        payload = WebHook.generate_payload(:post, post)
+        WebHook.enqueue_category_experts_hooks(category_experts_event, post, payload)
+      end
     end
   end
 

--- a/spec/fabricators/outgoing_category_experts_web_hook_fabricator.rb
+++ b/spec/fabricators/outgoing_category_experts_web_hook_fabricator.rb
@@ -9,6 +9,7 @@ Fabricator(:outgoing_category_experts_web_hook, from: :web_hook) do
   active true
 
   after_build do |web_hook|
-    web_hook.web_hook_event_types = WebHookEventType.where(name: %w[category_experts_approved])
+    web_hook.web_hook_event_types =
+      WebHookEventType.where(name: %w[category_experts_approved category_experts_unapproved])
   end
 end

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -233,5 +233,18 @@ describe CategoryExperts::PostHandler do
         }
         .once
     end
+
+    it "sends a webhook event when a post is unapproved" do
+      post = create_post(topic_id: topic.id, user: expert)
+      # CategoryExperts::PostHandler.new(post: post).mark_post_for_approval
+
+      expect(WebMock).to have_requested(:post, webhook.payload_url)
+        .with { |req|
+          json = JSON.parse(req.body)
+          req.headers["X-Discourse-Event"] == "category_experts_unapproved" &&
+            json.dig("post", "id") == post.id
+        }
+        .once
+    end
   end
 end

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -212,6 +212,7 @@ describe CategoryExperts::PostHandler do
 
   describe "Webhook integration" do
     fab!(:webhook) { Fabricate(:outgoing_category_experts_web_hook) }
+    fab!(:post) { create_post(topic_id: topic.id, user: expert) }
 
     before do
       SiteSetting.category_experts_posts_require_approval = true
@@ -222,7 +223,6 @@ describe CategoryExperts::PostHandler do
     end
 
     it "sends a webhook event when a post is approved" do
-      post = create_post(topic_id: topic.id, user: expert)
       CategoryExperts::PostHandler.new(post: post).mark_post_as_approved
 
       expect(WebMock).to have_requested(:post, webhook.payload_url)
@@ -235,8 +235,7 @@ describe CategoryExperts::PostHandler do
     end
 
     it "sends a webhook event when a post is unapproved" do
-      post = create_post(topic_id: topic.id, user: expert)
-      # CategoryExperts::PostHandler.new(post: post).mark_post_for_approval
+      CategoryExperts::PostHandler.new(post: post).mark_post_for_approval
 
       expect(WebMock).to have_requested(:post, webhook.payload_url)
         .with { |req|


### PR DESCRIPTION
### Changes

This PR is adding a WebHook Event for the post that is approved by the Category Experts.

This is the screenshot for the Category Experts approved webhook event option:

<img width="1018" alt="Screenshot 2024-09-09 at 3 18 11 PM" src="https://github.com/user-attachments/assets/c15b9aa6-9556-4120-a9c1-4db3cda8d737">