### PR TITLE
FIX: new post sending unapproved post webhook event

### DIFF
--- a/app/controllers/category_experts_controller.rb
+++ b/app/controllers/category_experts_controller.rb
@@ -72,14 +72,14 @@ class CategoryExpertsController < ApplicationController
 
   def approve_post
     post_handler = CategoryExperts::PostHandler.new(post: @post)
-    group_name = post_handler.mark_post_as_approved
+    group_name = post_handler.mark_post_as_approved(new_post: false)
 
     render json: { group_name: group_name }.merge(topic_custom_fields)
   end
 
   def unapprove_post
     post_handler = CategoryExperts::PostHandler.new(post: @post)
-    post_handler.mark_post_for_approval
+    post_handler.mark_post_for_approval(new_post: false)
 
     render json: topic_custom_fields
   end

--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -24,7 +24,7 @@ module CategoryExperts
       end
     end
 
-    def mark_post_for_approval(skip_validations: false)
+    def mark_post_for_approval(skip_validations: false, new_post: true)
       if !skip_validations
         raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
       end
@@ -67,12 +67,12 @@ module CategoryExperts
 
       topic.save!
 
-      DiscourseEvent.trigger(:category_experts_unapproved, post)
+      DiscourseEvent.trigger(:category_experts_unapproved, post) unless new_post
 
       remove_auto_tag if should_remove_auto_tag
     end
 
-    def mark_post_as_approved(skip_validations: false)
+    def mark_post_as_approved(skip_validations: false, new_post: true)
       if !skip_validations
         raise Discourse::InvalidParameters unless ensure_poster_is_category_expert
       end
@@ -97,7 +97,7 @@ module CategoryExperts
 
       topic.save!
 
-      DiscourseEvent.trigger(:category_experts_approved, post)
+      DiscourseEvent.trigger(:category_experts_approved, post) unless new_post
 
       add_auto_tag
       users_expert_group.name


### PR DESCRIPTION
This PR is to fix the issue when a new post is created, it sends a `category-experts unapproved post` webhook event.

### Changes

Check if it is a new post and does not send `category-experts unapproved post` webhook event.