### PR TITLE
FEATURE: Add Category-Experts webhook event types

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,6 +4,10 @@ en:
       site_settings:
         categories:
           discourse_category_experts: "Discourse Category Experts"
+      web_hooks:
+        post_event:
+          category_experts_approved: "Post marked as category experts post"
+          category_experts_unapproved: "Post unmarked as category experts post"
   js:
     category_experts:
       title: "Category Experts"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6,8 +6,8 @@ en:
           discourse_category_experts: "Discourse Category Experts"
       web_hooks:
         post_event:
-          category_experts_approved: "Post marked as category experts post"
-          category_experts_unapproved: "Post unmarked as category experts post"
+          category_experts_approved: "Post is marked as category experts post"
+          category_experts_unapproved: "Post is unmarked as category experts post"
   js:
     category_experts:
       title: "Category Experts"

--- a/db/fixtures/007_category_experts_web_hook_event_types.rb
+++ b/db/fixtures/007_category_experts_web_hook_event_types.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::CATEGORY_EXPERTS_APPROVED
+  b.name = "category_experts_approved"
+  b.group = WebHookEventType.groups[:post]
+end
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::CATEGORY_EXPERTS_UNAPPROVED
+  b.name = "category_experts_unapproved"
+  b.group = WebHookEventType.groups[:post]
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -12,6 +12,14 @@ register_asset "stylesheets/common.scss"
 enabled_site_setting :enable_category_experts
 
 after_initialize do
+  WebHookEventType.const_set(:CATEGORY_EXPERTS_APPROVED, 30_478)
+  WebHookEventType.const_set(:CATEGORY_EXPERTS_UNAPPROVED, 30_479)
+
+  SeedFu.fixture_paths << Rails
+    .root
+    .join("plugins", "discourse-category-experts", "db", "fixtures")
+    .to_s
+
   module ::CategoryExperts
     PLUGIN_NAME ||= "discourse-category-experts".freeze
     CATEGORY_EXPERT_GROUP_IDS = "category_expert_group_ids"


### PR DESCRIPTION
### Changes

This PR adds Category Experts webhook events types:
<img width="978" alt="Screenshot 2024-10-23 at 2 07 16 PM" src="https://github.com/user-attachments/assets/64f66b15-6ea0-4f05-9c1b-757766ac2333">
