### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: fceeb968ed87ef5a27e3ec0f755f51359dedb067
 < 3.4.0.beta1-dev: 67c15e7f46de937b7a763d09ec05cabfa66bded0
 < 3.3.0.beta1-dev: adcd268777ebe1f110e0cca3b42050d61b3927bd
 < 3.2.0.beta1-dev: 23f72e84a71128f7ea31fc38226a9475fb357489

--- a/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
+++ b/assets/javascripts/discourse/initializers/category-experts-post-decorator.js
@@ -46,7 +46,7 @@ function initializeWithApi(api) {
     if (post && post.category_expert_approved_group) {
       return helper.h(
         `span.category-expert-indicator.category-expert-${post.category_expert_approved_group}`,
-        iconNode("check-circle")
+        iconNode("circle-check")
       );
     }
   });


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.