### PR TITLE
DEV: Replace deprecated Ember's array `filterBy` with `filter`

### DIFF
--- a/assets/javascripts/discourse/components/category-experts-settings.gjs
+++ b/assets/javascripts/discourse/components/category-experts-settings.gjs
@@ -26,7 +26,10 @@ export default class CategoryExpertsSettings extends Component {
     );
 
     Group.findAll().then((groups) => {
-      this.set("allGroups", groups.filterBy("automatic", false));
+      this.set(
+        "allGroups",
+        groups.filter((group) => !group.automatic)
+      );
     });
 
     if (this.siteSettings.enable_badges) {


### PR DESCRIPTION
Replace `filterBy` with an explicit `filter` function for clarity and consistency. This change ensures improved readability and aligns with modern code practices without altering functionality.