### PR TITLE
FIX: Use `save_custom_fields` instead of `save!` when only custom fie…

### DIFF
--- a/lib/category_experts/post_handler.rb
+++ b/lib/category_experts/post_handler.rb
@@ -36,7 +36,7 @@ module CategoryExperts
 
       post.custom_fields.delete(CategoryExperts::POST_APPROVED_GROUP_NAME)
       post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = true
-      post.save!
+      post.save_custom_fields
 
       correct_topic_custom_fields_after_removal(group_name: post_group_name, new_post: new_post)
     end
@@ -51,7 +51,7 @@ module CategoryExperts
 
       post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME] = users_expert_group.name
       post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL] = false
-      post.save!
+      post.save_custom_fields
 
       correct_topic_custom_fields_after_addition(new_post: new_post)
 
@@ -63,7 +63,7 @@ module CategoryExperts
       raise Discourse::InvalidParameters unless topic.category.accepting_category_expert_questions?
 
       topic.custom_fields[CategoryExperts::TOPIC_IS_CATEGORY_EXPERT_QUESTION] = true
-      topic.save!
+      topic.save_custom_fields
     end
 
     def correct_topic_custom_fields_after_removal(
@@ -101,7 +101,7 @@ module CategoryExperts
         topic.custom_fields.delete(CategoryExperts::TOPIC_NEEDS_EXPERT_POST_APPROVAL)
       end
 
-      topic.save!
+      topic.save_custom_fields
 
       DiscourseEvent.trigger(:category_experts_unapproved, post) if post && !new_post
 
@@ -119,7 +119,7 @@ module CategoryExperts
         topic.custom_fields[CategoryExperts::TOPIC_FIRST_EXPERT_POST_ID] = post.post_number
       end
 
-      topic.save!
+      topic.save_custom_fields
 
       DiscourseEvent.trigger(:category_experts_approved, post) unless new_post
 
@@ -160,7 +160,7 @@ module CategoryExperts
           old_group_name = expert_post.custom_fields[CategoryExperts::POST_APPROVED_GROUP_NAME]
           expert_post.custom_fields.delete(CategoryExperts::POST_APPROVED_GROUP_NAME)
           expert_post.custom_fields.delete(CategoryExperts::POST_PENDING_EXPERT_APPROVAL)
-          expert_post.save!
+          expert_post.save_custom_fields
 
           # Update topic custom fields to reflect the removal
           CategoryExperts::PostHandler.new(
@@ -180,7 +180,7 @@ module CategoryExperts
             expert_post.custom_fields[
               CategoryExperts::POST_APPROVED_GROUP_NAME
             ] = new_expert_group.name
-            expert_post.save!
+            expert_post.save_custom_fields
 
             # Remove old group from topic custom fields (now that post is updated)
             CategoryExperts::PostHandler.new(

--- a/plugin.rb
+++ b/plugin.rb
@@ -348,7 +348,7 @@ after_initialize do
     previously_approved = !post.custom_fields[CategoryExperts::POST_PENDING_EXPERT_APPROVAL]
     post.custom_fields.delete(CategoryExperts::POST_APPROVED_GROUP_NAME)
     post.custom_fields.delete(CategoryExperts::POST_PENDING_EXPERT_APPROVAL)
-    post.save!
+    post.save_custom_fields
     CategoryExperts::PostHandler.new(post: post, user: new_owner).process_new_post(
       previously_approved: previously_approved,
     )

--- a/spec/lib/post_handler_spec.rb
+++ b/spec/lib/post_handler_spec.rb
@@ -149,6 +149,21 @@ describe CategoryExperts::PostHandler do
           )
         end
       end
+
+      describe "when the post has content that doesn't pass validations" do
+        it "does not raise an error" do
+          post = topic.add_small_action(expert, "invited_user")
+
+          expect {
+            PostOwnerChanger.new(
+              post_ids: [post.id],
+              topic_id: topic.id,
+              new_owner: second_expert,
+              acting_user: admin,
+            ).change_owner!
+          }.not_to raise_error
+        end
+      end
     end
   end
 


### PR DESCRIPTION
…lds changed

During user merges, `PostOwnerChanger` reassigns all post types including small action posts which have `raw: nil` by design. The core `set_owner` method handles this correctly via `skip_validations: true`, but the plugin's `post_owner_changed` handler and `PostHandler` methods were calling `save!` after only modifying custom fields. This triggered full AR validations on the post body, raising `ActiveRecord::RecordInvalid` for posts with content that doesn't pass current validation rules.

Replace all `save!` calls with `save_custom_fields` in places where only custom fields are being modified — 8 occurrences across `plugin.rb` and `PostHandler` (`mark_post_for_approval`, `mark_post_as_approved`, `mark_topic_as_question`, `correct_topic_custom_fields_after_removal`, `correct_topic_custom_fields_after_addition`, `handle_topic_category_change`).

https://meta.discourse.org/t/399785