### PR TITLE
DEV: Expect handled category expert reviewables to leave list

### DIFF
--- a/spec/system/reviewable_category_expert_suggestion_spec.rb
+++ b/spec/system/reviewable_category_expert_suggestion_spec.rb
@@ -51,7 +51,7 @@ describe "Reviewables - Category expert suggestion" do
       expect(modal).to have_content(group.name)
       find("#tap_tile_#{group.id}").click
 
-      expect(review_page).to have_reviewable_with_approved_status(reviewable)
+      expect(review_page).to have_no_reviewable(reviewable)
       expect(reviewable.reload.status).to eq("approved")
     end
 
@@ -65,7 +65,8 @@ describe "Reviewables - Category expert suggestion" do
 
       find(".category-expert-endorsement-deny-category-expert", text: /Ignore/).click
 
-      expect(review_page).to have_reviewable_with_rejected_status(reviewable)
+      expect(review_page).to have_no_reviewable(reviewable)
+      expect(reviewable.reload.status).to eq("rejected")
     end
   end
 end


### PR DESCRIPTION
Handled reviewables leave the loaded review list after an action completes, while their persisted status still records the moderator decision.

This PR updates the category expert endorsement system specs to assert the row removal in the list and the resulting approved or rejected status on the reviewable.

Related core PR: https://github.com/discourse/discourse/pull/40559